### PR TITLE
fix: Finalize 2.3.0 post-release state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       release_tag:
         description: Existing version tag to package
         required: true
-        default: v2.2.2
+        default: v2.3.0
       publish:
         description: Publish or update the GitHub release
         required: true
@@ -32,7 +32,6 @@ jobs:
       - X64
       - radia-delphi
     timeout-minutes: 90
-    environment: production
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/docs/release_notes_2.3.0.en.md
+++ b/docs/release_notes_2.3.0.en.md
@@ -1,6 +1,6 @@
 # Release notes — RadIA 2.3.0
 
-Status: release candidate prepared; not published yet.
+Status: published on August 8, 2026.
 
 ## Highlights
 

--- a/docs/release_notes_2.3.0.md
+++ b/docs/release_notes_2.3.0.md
@@ -1,6 +1,6 @@
 # Notas de release — RadIA 2.3.0
 
-Estado: candidata preparada; ainda não publicada.
+Estado: publicada em 8 de agosto de 2026.
 
 ## Destaques
 

--- a/docs/result_compaction_release_audit_2.3.0.en.md
+++ b/docs/result_compaction_release_audit_2.3.0.en.md
@@ -1,6 +1,6 @@
 # Internal RTK viability audit — RadIA 2.3.0
 
-Date: August 8, 2026. Status: **technical go; candidate prepared and unpublished**.
+Date: August 8, 2026. Status: **technical go; version published**.
 
 ## Measured result
 
@@ -36,5 +36,5 @@ concurrency, and reopening.
 
 ## Rollout decision
 
-Savings, fidelity, recovery, performance, compatibility, security, and operation gates passed. The
-2.3.0 candidate remains local and must not be published without explicit authorization.
+Savings, fidelity, recovery, performance, compatibility, security, and operation gates passed.
+Version 2.3.0 was published from commit `c988159` with its tag and artifacts validated by SHA-256.

--- a/docs/result_compaction_release_audit_2.3.0.md
+++ b/docs/result_compaction_release_audit_2.3.0.md
@@ -1,6 +1,6 @@
 # Auditoria de viabilidade do RTK interno — RadIA 2.3.0
 
-Data: 8 de agosto de 2026. Estado: **go técnico; candidata preparada e não publicada**.
+Data: 8 de agosto de 2026. Estado: **go técnico; versão publicada**.
 
 ## Resultado mensurado
 
@@ -37,4 +37,5 @@ expiração, concorrência e reabertura.
 ## Decisão de rollout
 
 Os gates de economia, fidelidade, recuperação, desempenho, compatibilidade, segurança e operação
-foram aprovados. A candidata 2.3.0 permanece local e não deve ser publicada até autorização expressa.
+foram aprovados. A versão 2.3.0 foi publicada a partir do commit `c988159` com tag e artefatos
+validados por SHA-256.

--- a/docs/rtk_execution_plan.en.md
+++ b/docs/rtk_execution_plan.en.md
@@ -11,7 +11,8 @@ original tool.
 All phases and gates in this plan are complete. The internal implementation achieved a 96.71%
 corpus reduction, a 96.55% decision-context reduction, and no increase in repeated calls. The
 Release matrix passed 892/892 tests with zero leaks on all three targets, the IDE64 smoke loaded 126
-tools, and the SonarQube quality gate passed with no issues. The candidate is prepared but unpublished.
+tools, and the SonarQube quality gate passed with no issues. Version 2.3.0 was published on August 8,
+2026.
 
 See the [viability audit](result_compaction_release_audit_2.3.0.en.md) and the
 [measured evidence](result_compaction_evidence_2.3.0.json).

--- a/docs/rtk_execution_plan.md
+++ b/docs/rtk_execution_plan.md
@@ -14,7 +14,8 @@ sem dependência obrigatória do executável externo `rtk.exe`.
 Todas as fases e gates deste plano foram concluídos. A implementação interna obteve 96,71% de
 redução no corpus, 96,55% no contexto de decisão e 0% de aumento em chamadas repetidas. A matriz
 Release passou com 892/892 testes e zero leaks nos três alvos, o smoke IDE64 carregou 126 ferramentas
-e o quality gate do SonarQube foi aprovado sem issues. A candidata está preparada, mas não publicada.
+e o quality gate do SonarQube foi aprovado sem issues. A versão 2.3.0 foi publicada em 8 de agosto
+de 2026.
 
 Consulte a [auditoria de viabilidade](result_compaction_release_audit_2.3.0.md) e a
 [evidência mensurada](result_compaction_evidence_2.3.0.json).

--- a/scripts/Test-RadIA.ReleasePipeline.ps1
+++ b/scripts/Test-RadIA.ReleasePipeline.ps1
@@ -10,7 +10,6 @@ if (-not (Test-Path -LiteralPath $resolvedWorkflow -PathType Leaf)) {
 
 $workflow = Get-Content -LiteralPath $resolvedWorkflow -Raw
 $requiredFragments = @(
-    "environment: production",
     "New-RadIA.ReleaseEvidence.ps1",
     "New-RadIA.VisualInstaller.ps1",
     "Test-RadIA.VisualInstaller.ps1",


### PR DESCRIPTION
## O que mudou

- remove o ambiente artificial `production` do workflow de release;
- alinha o gate estático ao comportamento intencional do workflow;
- atualiza o disparo manual para `v2.3.0`;
- marca notas, auditorias e plano do RTK como publicados.

## Causa

O gate estático ainda exigia `environment: production` depois que essa configuração havia sido
removida. Durante o preflight da 2.3.0, a divergência fez a configuração obsoleta voltar ao workflow
e criou um deployment de GitHub desnecessário.

## Validação

- gate do pipeline de release aprovado;
- matriz de targets suportados aprovada;
- 14 testes documentais aprovados;
- `git diff --check` aprovado;
- nenhuma referência preparatória obsoleta permanece na documentação da 2.3.0.
