### PR TITLE
docs: Synchronize backlog with delivered gates

### DIFF
--- a/Tests/Web/RadIA.Documentation.test.js
+++ b/Tests/Web/RadIA.Documentation.test.js
@@ -611,7 +611,7 @@ test('current release gates use the generated catalog size', () => {
 test('release keeps integration, calculator, and project journeys indivisible', () => {
   const portuguese = fs.readFileSync(documentationPath('release_process.md'), 'utf8');
   const english = fs.readFileSync(documentationPath('release_process.en.md'), 'utf8');
-  const backlog = fs.readFileSync(documentationPath('project', 'backlog.md'), 'utf8');
+  const usageMatrix = fs.readFileSync(documentationPath('usage_test_matrix.md'), 'utf8');
   const releaseRunner = fs.readFileSync(
     path.join(repositoryRoot, 'scripts', 'Test-RadIA.ReleaseUsage.ps1'),
     'utf8'
@@ -619,7 +619,8 @@ test('release keeps integration, calculator, and project journeys indivisible', 
 
   assert.match(portuguese, /toda a suíte registrada de integração e ponta a ponta/u);
   assert.match(english, /entire registered integration and end-to-end suite/u);
-  assert.match(backlog, /sem\s+opções de exclusão/u);
+  assert.match(usageMatrix, /sem opções para pular os gates principais/u);
+  assert.match(usageMatrix, /não aceita filtro, exclusão ou aprovação parcial/u);
   assert.match(releaseRunner, /build\.ps1[\s\S]*-Test/u);
   assert.match(releaseRunner, /Test-RadIA\.GeneratedProjects\.ps1/u);
   assert.match(releaseRunner, /Test-RadIA\.ProjectCreationNavigation\.ps1/u);
@@ -1151,7 +1152,9 @@ test('planning and update documentation follow the new separation', () => {
   assert.match(englishHub, /organized by task,[\s\S]*not by release/u);
   assert.doesNotMatch(portugueseBacklog, /\.planning\//u);
   assert.doesNotMatch(englishBacklog, /\.planning\//u);
-  assert.match(portugueseBacklog, /não registra versões, entregas concluídas, evidências/u);
-  assert.match(englishBacklog, /does not record versions, completed deliveries, evidence/u);
+  assert.match(portugueseBacklog, /Não existe goal ativo nem item aberto aprovado/u);
+  assert.match(englishBacklog, /There is no active goal or approved open item/u);
+  assert.doesNotMatch(portugueseBacklog, /^\s*- \[ \]/mu);
+  assert.doesNotMatch(englishBacklog, /^\s*- \[ \]/mu);
   assert.doesNotMatch(releaseWorkflow, /Output\\Distribution\\stable\.json/u);
 });

--- a/docs/development/tool_catalog.en.md
+++ b/docs/development/tool_catalog.en.md
@@ -355,7 +355,8 @@ External tools do not have an alternative execution path: chat and MCP continue 
 central enforcer of policy, consent, audit and opt-out. The release of the token
 `IRadIAToolExtensionRegistration` removes only tools belonging to the extension.
 
-See `docs/tool_extension_guide.md` and the package at `Examples/ToolExtension`.
+See the [tool extension guide](tool_extension_guide.en.md) and the package at
+`Examples/ToolExtension`.
 
 ## 13. Criteria for adding a tool
 

--- a/docs/development/tool_catalog.md
+++ b/docs/development/tool_catalog.md
@@ -355,7 +355,8 @@ Ferramentas externas não possuem um caminho alternativo de execução: chat e M
 executor central de política, consentimento, auditoria e cancelamento. A liberação do token
 `IRadIAToolExtensionRegistration` remove somente as ferramentas pertencentes à extensão.
 
-Consulte `docs/tool_extension_guide.md` e o pacote em `Examples/ToolExtension`.
+Consulte o [guia de extensões de tools](tool_extension_guide.md) e o pacote em
+`Examples/ToolExtension`.
 
 ## 13. Critérios para adicionar uma ferramenta
 

--- a/docs/getting-started/install_config.en.md
+++ b/docs/getting-started/install_config.en.md
@@ -167,7 +167,11 @@ Enter the obtained keys in the plugin settings (**Settings** at the top of the c
    > * The IAM access key used must have security policies attached that allow executing the actions `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream`.
    > * By default, AWS Bedrock requires you to request access to models individually in the AWS Console for the intended region (*Model Access* menu). Confirm that the selected model is enabled for the account and region before connecting it in Rad IA.
 
-> **Note on Dynamic and Enterprise Providers:** You can also dynamically add new OpenAI-compatible API providers (such as GitHub Copilot or third-party proxies) by saving JSON configuration files under `%APPDATA%\RadIA\providers\`. For more details, check our [Guide for Adding New Providers (docs/new_provider_guide.en.md)](../development/new_provider_guide.en.md) and the [GitHub Copilot Configuration Guide (docs/copilot_proxy_guide.en.md)](../guides/copilot_proxy_guide.en.md).
+> **Note on Dynamic and Enterprise Providers:** You can also dynamically add new OpenAI-compatible
+> API providers, including GitHub Copilot or third-party proxies, by saving JSON configuration files
+> under `%APPDATA%\RadIA\providers\`. For details, see the
+> [guide for adding new providers](../development/new_provider_guide.en.md) and the
+> [GitHub Copilot configuration guide](../guides/copilot_proxy_guide.en.md).
 
 ---
 

--- a/docs/getting-started/install_config.md
+++ b/docs/getting-started/install_config.md
@@ -167,7 +167,11 @@ Insira as chaves obtidas nas configurações do plugin (**Settings** no topo do 
    > * A chave de acesso IAM utilizada deve possuir políticas de segurança anexadas que permitam a execução das ações `bedrock:InvokeModel` e `bedrock:InvokeModelWithResponseStream`.
    > * Por padrão, a AWS Bedrock exige que você solicite acesso aos modelos individualmente no Console AWS da região desejada (menu *Model Access*). Confirme que o modelo escolhido está liberado para a conta e a região antes de tentar conectá-lo no Rad IA.
 
-> **Nota sobre Provedores Dinâmicos e Corporativos:** Você também pode adicionar de forma dinâmica novos provedores compatíveis com a API OpenAI (incluindo o GitHub Copilot ou proxies de terceiros) salvando arquivos JSON em `%APPDATA%\RadIA\providers\`. Para mais detalhes, consulte o [Guia para Adição de Novos Provedores (docs/new_provider_guide.md)](../development/new_provider_guide.md) e o [Guia de Configuração do GitHub Copilot (docs/copilot_proxy_guide.md)](../guides/copilot_proxy_guide.md).
+> **Nota sobre Provedores Dinâmicos e Corporativos:** Você também pode adicionar de forma dinâmica
+> novos provedores compatíveis com a API OpenAI, incluindo o GitHub Copilot ou proxies de terceiros,
+> salvando arquivos JSON em `%APPDATA%\RadIA\providers\`. Para mais detalhes, consulte o
+> [guia para adicionar novos provedores](../development/new_provider_guide.md) e o
+> [guia de configuração do GitHub Copilot](../guides/copilot_proxy_guide.md).
 
 ---
 

--- a/docs/guides/mcp_integration_guide.en.md
+++ b/docs/guides/mcp_integration_guide.en.md
@@ -218,7 +218,7 @@ See also the [Complete RadIA User Manual](user_manual.en.md).
 
 ## Safe CLI client provisioning
 
-RadIA 2.2 includes a provisioning engine for Codex CLI, Claude Code, Gemini CLI, and GitHub Copilot
+RadIA includes a provisioning engine for Codex CLI, Claude Code, Gemini CLI, and GitHub Copilot
 CLI. Its visual integration is available on the settings screen, while the core contract
 enforces this workflow:
 

--- a/docs/guides/mcp_integration_guide.md
+++ b/docs/guides/mcp_integration_guide.md
@@ -257,7 +257,7 @@ continuam exibindo o consentimento na IDE. Para detalhes, consulte
 
 ## Provisionamento seguro dos clientes CLI
 
-O RadIA 2.2 possui um mecanismo visual de provisionamento para Codex CLI, Claude Code, Gemini CLI e
+O RadIA possui um mecanismo visual de provisionamento para Codex CLI, Claude Code, Gemini CLI e
 GitHub Copilot CLI. O contrato central garante que o processo siga estas etapas:
 
 1. detectar se a configuração está ausente, válida, divergente ou inválida;

--- a/docs/guides/terminal.en.md
+++ b/docs/guides/terminal.en.md
@@ -4,7 +4,7 @@ When a journey is linked in chat, the terminal header shows the same identifier,
 activity state. Command authorization uses that identity without submitting chat history or previous
 output. See [Shared context](shared_journey_context.en.md).
 
-RadIA 2.0 includes a native terminal that can be plugged into the IDE. It is available on all three targets
+RadIA includes a native terminal that can be plugged into the IDE. It is available on all three targets
 official: Delphi 12 Win32, Delphi 13 Win32 and Delphi 13 IDE64.
 
 ## How to open

--- a/docs/guides/terminal.md
+++ b/docs/guides/terminal.md
@@ -4,7 +4,7 @@ Quando uma jornada está vinculada no chat, o cabeçalho do terminal mostra o me
 projeto e estado de atividade. A autorização do comando usa essa identidade sem enviar o histórico
 do chat ou a saída anterior. Veja [Contexto compartilhado](shared_journey_context.md).
 
-O RadIA 2.0 inclui um terminal nativo acoplável à IDE. Ele está disponível nos três targets
+O RadIA inclui um terminal nativo acoplável à IDE. Ele está disponível nos três targets
 oficiais: Delphi 12 Win32, Delphi 13 Win32 e Delphi 13 IDE64.
 
 ## Como abrir

--- a/docs/project/backlog.en.md
+++ b/docs/project/backlog.en.md
@@ -3,41 +3,23 @@
 This file contains open work only. History, completed milestones, metrics, and release notes do not
 belong in the backlog.
 
-The backlog does not record versions, completed deliveries, evidence, or internal plans.
+## Current status
 
-## Active goal: complete and deterministic Delphi experience
+There is no active goal or approved open item in the public backlog.
 
-Turn common Delphi developer objectives into simple, safe, and verifiable flows, reusing existing
-tools before expanding the catalog.
+The deterministic integration and end-to-end platform previously recorded as pending is complete.
+The mandatory `Test-RadIA.ReleaseUsage.ps1` gate brings together the Delphi 12 and 13 DUnitX suites,
+registered integration and usage scenarios, the calculator, project generation and opening, and the
+automated matrix on all three supported targets. Its current contract is documented in the
+[automated usage test matrix](../development/usage_test_matrix.en.md).
 
-The only open workstream is consolidation of the automated usage platform. Internal engineering
-plans remain separate from public documentation.
+New proposals enter this file only after they are approved as executable work with an observable
+outcome and acceptance criteria. Ideas that have not been approved are not presented as product
+commitments.
 
-## Cross-cutting foundation — automated usage tests
+## Definition of done for new items
 
-- [ ] **Integration and end-to-end platform:** automate isolated installation, Delphi startup,
-  sanitized configuration, chat, tools, editor, Designer, build, tests, debugger, terminal, consent,
-  and failure recovery on Delphi 12 and 13 targets.
-
-The platform must have three layers:
-
-1. service and adapter integration without opening the IDE;
-2. OTA integration loaded into a disposable Delphi instance;
-3. end-to-end user journeys with fixture projects, real actions, and verifiable evidence.
-
-Gate: a clean run must install RadIA in an isolated environment, open every supported IDE, execute
-the critical matrix, collect logs, screenshots, and structured results, and restore the environment
-without human intervention. Failures must identify the stage, IDE version, and diagnostic artifact
-without exposing credentials.
-
-This gate is mandatory for every release. Publication must run, through the same command and without
-skip options, the complete integration and end-to-end suite, calculator creation plus its functional
-and DUnitX tests, and immediate project creation, opening, and navigation. A missing, skipped, or
-failed group blocks the release.
-
-## Definition of done
-
-Each item requires:
+Every new item must require:
 
 - a documented contract and threat model before implementation;
 - proven Delphi 12 and 13 support, with unavailable capabilities reported explicitly;

--- a/docs/project/backlog.md
+++ b/docs/project/backlog.md
@@ -3,41 +3,23 @@
 Este arquivo contém somente trabalho aberto. Histórico, marcos concluídos, métricas e notas de
 release não pertencem ao backlog.
 
-O backlog não registra versões, entregas concluídas, evidências ou planos internos.
+## Estado atual
 
-## Goal ativo: experiência Delphi completa e determinística
+Não existe goal ativo nem item aberto aprovado no backlog público.
 
-Transformar objetivos comuns do programador Delphi em fluxos simples, seguros e verificáveis,
-aproveitando as ferramentas existentes antes de ampliar o catálogo.
+A plataforma determinística de integração e ponta a ponta que constava anteriormente como pendente
+foi concluída. O gate obrigatório `Test-RadIA.ReleaseUsage.ps1` reúne as suítes DUnitX do Delphi 12
+e 13, os cenários registrados de integração e uso, a calculadora, a geração e abertura de projetos e
+a matriz automatizada nos três alvos suportados. O contrato vigente está na
+[matriz automatizada de testes de uso](../development/usage_test_matrix.md).
 
-A única frente aberta é a consolidação da plataforma automatizada de uso. Planos internos de
-engenharia permanecem separados da documentação pública.
+Novas propostas somente entram neste arquivo depois de aprovadas como trabalho executável, com
+resultado observável e critérios de aceitação. Ideias ainda não aprovadas não são apresentadas como
+compromisso do produto.
 
-## Fundação transversal — testes automatizados de uso
+## Definição de concluído para novos itens
 
-- [ ] **Plataforma de integração e ponta a ponta:** automatizar instalação isolada, abertura do
-  Delphi, configuração sanitizada, chat, tools, editor, Designer, build, testes, debugger, terminal,
-  consentimento e recuperação de falhas nos alvos Delphi 12 e 13.
-
-A plataforma deve possuir três camadas:
-
-1. integração de serviços e adapters sem abrir a IDE;
-2. integração OTA carregada em uma instância descartável do Delphi;
-3. jornadas de usuário ponta a ponta com projetos-fixture, ações reais e evidências verificáveis.
-
-Gate: uma execução limpa deve instalar o RadIA em ambiente isolado, abrir cada IDE suportada,
-executar a matriz crítica, coletar logs, screenshots e resultados estruturados e restaurar o ambiente
-sem depender de intervenção humana. Falhas precisam identificar etapa, versão da IDE e artefato de
-diagnóstico, sem expor credenciais.
-
-Esse gate integra obrigatoriamente toda release. A publicação deve executar, no mesmo comando e sem
-opções de exclusão, a suíte completa de integração e ponta a ponta, a criação e os testes funcionais e
-DUnitX da calculadora e a criação, abertura e navegação imediata de projetos. Um desses grupos ausente,
-ignorado ou reprovado bloqueia a release.
-
-## Definição de concluído
-
-Cada item precisa de:
+Cada novo item deverá exigir:
 
 - contrato e ameaça documentados antes da implementação;
 - suporte comprovado no Delphi 12 e 13, com capacidade indisponível reportada explicitamente;

--- a/docs/project/roadmap.en.md
+++ b/docs/project/roadmap.en.md
@@ -6,14 +6,15 @@ the [backlog](backlog.en.md).
 
 ## Current direction
 
-Consolidate the complete Delphi 12 and 13 experience through real usage: create, understand, build,
-test, and debug projects without requiring users to know the internal architecture. New initiatives
-enter execution only with an observable outcome and an acceptance criterion.
+Maintain and deepen the complete Delphi 12 and 13 experience through real usage: create, understand,
+build, test, and debug projects without requiring users to know the internal architecture. Future
+evolution must first demonstrate an observable gain for this flow and have verifiable acceptance
+criteria.
 
-## Current goal
+## Planning status
 
-The open work prioritizes one deterministic integration and end-to-end automation platform for the
-complete Delphi experience. The executable scope and its gates are in the
-[backlog](backlog.en.md); the roadmap does not reserve versions or keep speculative lists.
+There is no active executable goal. The automated integration and end-to-end foundation is complete
+and now belongs to the mandatory gate for every release. The official open state remains in the
+[backlog](backlog.en.md), which currently has no approved items.
 
 Delphi 11, C++, Lazarus, marketplace work, and DCU reading remain outside the current direction.

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -6,14 +6,15 @@ no [backlog](backlog.md).
 
 ## Direção atual
 
-Consolidar a experiência completa no Delphi 12 e 13 com base em uso real: criar, compreender,
-compilar, testar e depurar projetos sem exigir que o usuário conheça a arquitetura interna. Novas
-frentes só entram em execução quando possuírem resultado observável e critério de aceitação.
+Manter e aprofundar a experiência completa no Delphi 12 e 13 com base em uso real: criar,
+compreender, compilar, testar e depurar projetos sem exigir que o usuário conheça a arquitetura
+interna. Evoluções futuras devem primeiro demonstrar ganho observável para esse fluxo e possuir
+critérios de aceitação verificáveis.
 
-## Goal atual
+## Estado de planejamento
 
-O trabalho aberto prioriza uma plataforma automatizada e determinística de integração e ponta a
-ponta para a experiência Delphi completa. O escopo executável e seus gates estão no
-[backlog](backlog.md); o roadmap não reserva versões nem mantém listas especulativas.
+Não existe goal executável ativo. A fundação automatizada de integração e ponta a ponta foi
+concluída e passou a integrar o gate obrigatório de toda release. O estado aberto oficial permanece
+no [backlog](backlog.md), que atualmente não possui itens aprovados.
 
 Delphi 11, C++, Lazarus, marketplace e leitura de DCU permanecem fora da direção atual.

--- a/docs/reference/features.en.md
+++ b/docs/reference/features.en.md
@@ -46,17 +46,17 @@ initialization/finalization, and imports outside the project, and applies throug
 | **Export Conversation** | Chat UX | Save current active chats to Markdown (.md) or standalone rich HTML formats. | ✅ Completed |
 | **Prompt Templates** | Chat UX | Quick prompt template library with token replacement and the `/template` command. | ✅ Completed |
 | **Dynamic Slash Commands** | Chat UX | Dynamic mapping of templates to slash commands (e.g. `/createprojectarch`), synced and autocompleted in WebView2. | ✅ Completed |
-| **RadIA Doctor and Status** | Diagnostics | `/doctor` checks readiness and recommends the next action; `/status` inventories configuration and availability without exposing credentials. | ✅ Completed (v2.2.1) |
+| **RadIA Doctor and Status** | Diagnostics | `/doctor` checks readiness and recommends the next action; `/status` inventories configuration and availability without exposing credentials. | ✅ Completed |
 | **Unified Problems panel** | Chat UX | Collects build, DUnitX, coverage, memory, DFM/PAS, threading, and review findings with filters, navigation, and reviewable actions. | ✅ Completed |
 | **Unified Delphi code validation** | Intelligence | Consolidates native rules, compiler Check, isolated DelphiLint, and Sonar into navigable findings; quick fixes become consented, reversible previews. | ✅ Completed |
 | **Hierarchy refactoring** | Intelligence | Coordinates compatible member renames across an ancestor, overrides, and exact usages, blocking overloads and ambiguous relationships before a reversible preview. | ✅ Completed |
-| **CLI/MCP Setup Assistant** | Integration | Detects, explains, requests consent, installs or configures, validates, and provides complete manual fallback without an IDE restart. | ✅ Completed (v2.2.1) |
-| **Explicit execution routes** | Chat UX | Separates Chat/Agent mode, RadIA native orchestration, and direct CLI while showing the effective route, transport, and credential. | ✅ Completed (v2.3.1) |
+| **CLI/MCP Setup Assistant** | Integration | Detects, explains, requests consent, installs or configures, validates, and provides complete manual fallback without an IDE restart. | ✅ Completed |
+| **Explicit execution routes** | Chat UX | Separates Chat/Agent mode, RadIA native orchestration, and direct CLI while showing the effective route, transport, and credential. | ✅ Completed |
 | **Intent recommendation** | Chat UX | Recognizes creation, build, tests, and diagnostics locally; lets users confirm, review, or remain in chat and keeps only sanitized local counters. | ✅ Completed |
-| **ChatGPT Pro via Codex CLI** | Provider | Uses the ChatGPT/Codex session and quota as either the native provider transport or direct CLI execution; API Key remains separate. | ✅ Completed (v2.3.1) |
-| **Universal text copy** | Chat UX | Adds copy actions to responses, JSON, tool results, and other textual payloads while preserving original content. | ✅ Completed (v2.3.1) |
-| **Integrated Help** | Chat UX | `/help` summarizes capabilities and opens public guides in the default browser. | ✅ Completed (v2.2.2) |
-| **Conversational DEXT Journeys** | Projects | Collects missing requirements across messages, preserves context, and generates minimal or controller-based APIs. | ✅ Completed (v2.2.2) |
+| **ChatGPT Pro via Codex CLI** | Provider | Uses the ChatGPT/Codex session and quota as either the native provider transport or direct CLI execution; API Key remains separate. | ✅ Completed |
+| **Universal text copy** | Chat UX | Adds copy actions to responses, JSON, tool results, and other textual payloads while preserving original content. | ✅ Completed |
+| **Integrated Help** | Chat UX | `/help` summarizes capabilities and opens public guides in the default browser. | ✅ Completed |
+| **Conversational DEXT Journeys** | Projects | Collects missing requirements across messages, preserves context, and generates minimal or controller-based APIs. | ✅ Completed |
 | **Declarative Skills and Templates** | Extensibility | Schema 2 manifest with hot reload, autocomplete, and minimal `chat.prompt` permission. | ✅ Completed |
 | **Declarative Tool Aliases** | Extensibility | Schema 3 registers safe chat/MCP aliases that inherit internal tool risk, schemas, and consent. | ✅ Completed |
 | **Declarative Workflows** | Extensibility | Schema 5 chains up to 16 internal tools with inherited risk, bounds, and per-step central policy, without arbitrary shells. | ✅ Completed |
@@ -125,7 +125,7 @@ initialization/finalization, and imports outside the project, and applies throug
 | **Transactional Change Signature** | Editor | Updates declarations, implementations, and confirmed calls with explicit parameter mapping, multi-file preview, and rollback. | ✅ Completed |
 | **Transactional Move Type** | Editor | Moves an interface type and its implementations between units, updates consumers and `uses`, blocks private dependencies or cycles, and applies only after approval. | ✅ Completed |
 | **Unicode and TUI Terminal** | Terminal | Incremental UTF-8 decoding, CJK, emoji, combining marks, reflow, and ICH/DCH/ECH operations over ConPTY. | ✅ Completed |
-| **High-fidelity terminal** | Terminal | True color, attributes, alternate screen, bracketed paste, SGR mouse, and consent-gated OSC 8 links. | ✅ Completed (v2.4.0) |
+| **High-fidelity terminal** | Terminal | True color, attributes, alternate screen, bracketed paste, SGR mouse, and consent-gated OSC 8 links. | ✅ Completed |
 | **Local Knowledge** | Agentic | Incremental, persistent, rebuildable, per-project index. | ✅ Completed |
 | **Tool Extensions** | Infrastructure | Versioned API and sample package for external tools. | ✅ Completed |
 | **Signed Declarative Extensions** | Security | RSA-SHA256 packages with fingerprints, first-use trust, and visual revocation. | ✅ Completed |

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -46,17 +46,17 @@ initialization/finalization e imports fora do projeto, e usa os patches reversí
 | **Exportação de Conversa** | Chat UX | Botão para salvar histórico nos formatos Markdown (.md) ou HTML autônomo com Prism.js. | ✅ Concluído |
 | **Templates de Prompt** | Chat UX | Biblioteca de templates rápidos de prompt com substituição de código e o comando `/template`. | ✅ Concluído |
 | **Slash Commands Dinâmicos** | Chat UX | Mapeamento dinâmico de templates para comandos de barra (ex: `/createprojectarch`), sincronizados e autocompletados no WebView2. | ✅ Concluído |
-| **Doctor e Status do RadIA** | Diagnóstico | `/doctor` verifica prontidão e recomenda a próxima ação; `/status` inventaria configuração e disponibilidade sem expor credenciais. | ✅ Concluído (v2.2.1) |
-| **Assistente CLI/MCP** | Integração | Detecta, explica, solicita consentimento, instala ou configura, valida e oferece fallback manual completo sem exigir reinício da IDE. | ✅ Concluído (v2.2.1) |
-| **Rotas explícitas de execução** | Chat UX | Separa modo Chat/Agent, orquestração RadIA native e CLI direto, mostrando rota, transporte e credencial efetivos. | ✅ Concluído (v2.3.1) |
+| **Doctor e Status do RadIA** | Diagnóstico | `/doctor` verifica prontidão e recomenda a próxima ação; `/status` inventaria configuração e disponibilidade sem expor credenciais. | ✅ Concluído |
+| **Assistente CLI/MCP** | Integração | Detecta, explica, solicita consentimento, instala ou configura, valida e oferece fallback manual completo sem exigir reinício da IDE. | ✅ Concluído |
+| **Rotas explícitas de execução** | Chat UX | Separa modo Chat/Agent, orquestração RadIA native e CLI direto, mostrando rota, transporte e credencial efetivos. | ✅ Concluído |
 | **Recomendação por intenção** | Chat UX | Reconhece criação, build, testes e diagnóstico localmente; permite confirmar, revisar ou continuar no chat e mantém somente contadores locais sanitizados. | ✅ Concluído |
 | **Painel de problemas unificado** | Chat UX | Reúne achados de build, DUnitX, cobertura, memória, DFM/PAS, threads e revisão com filtros, navegação e ações revisáveis. | ✅ Concluído |
 | **Validação unificada de código Delphi** | Inteligência | Consolida regras nativas, Check do compilador, DelphiLint isolado e Sonar em achados navegáveis; quick fixes viram previews consentidos e reversíveis. | ✅ Concluído |
 | **Refatoração de hierarquia** | Inteligência | Renomeia de forma coordenada membros compatíveis entre ancestral, overrides e usos exatos, bloqueando overloads e relações ambíguas antes do preview reversível. | ✅ Concluído |
-| **ChatGPT Pro via Codex CLI** | Provedor | Usa a sessão e a cota ChatGPT/Codex tanto como transporte do provider nativo quanto na execução CLI direta; API Key permanece separada. | ✅ Concluído (v2.3.1) |
-| **Cópia universal de texto** | Chat UX | Oferece cópia para respostas, JSON, resultados de tools e demais payloads textuais, preservando o conteúdo original. | ✅ Concluído (v2.3.1) |
-| **Ajuda integrada** | Chat UX | `/help` resume capacidades e abre os guias públicos no navegador padrão. | ✅ Concluído (v2.2.2) |
-| **Jornadas DEXT conversacionais** | Projetos | Coleta requisitos ausentes em várias mensagens, preserva o contexto e gera APIs minimalistas ou com controllers. | ✅ Concluído (v2.2.2) |
+| **ChatGPT Pro via Codex CLI** | Provedor | Usa a sessão e a cota ChatGPT/Codex tanto como transporte do provider nativo quanto na execução CLI direta; API Key permanece separada. | ✅ Concluído |
+| **Cópia universal de texto** | Chat UX | Oferece cópia para respostas, JSON, resultados de tools e demais payloads textuais, preservando o conteúdo original. | ✅ Concluído |
+| **Ajuda integrada** | Chat UX | `/help` resume capacidades e abre os guias públicos no navegador padrão. | ✅ Concluído |
+| **Jornadas DEXT conversacionais** | Projetos | Coleta requisitos ausentes em várias mensagens, preserva o contexto e gera APIs minimalistas ou com controllers. | ✅ Concluído |
 | **Skills e Templates Declarativos** | Extensibilidade | Manifesto schema 2 com hot reload, autocomplete e permissão mínima `chat.prompt`. | ✅ Concluído |
 | **Aliases Declarativos de Tools** | Extensibilidade | Schema 3 registra aliases seguros no chat e MCP, herdando risco, schemas e consentimento da tool interna. | ✅ Concluído |
 | **Workflows Declarativos** | Extensibilidade | Schema 5 encadeia até 16 tools internas com risco herdado, limites e policy central por etapa, sem shell arbitrário. | ✅ Concluído |
@@ -130,7 +130,7 @@ initialization/finalization e imports fora do projeto, e usa os patches reversí
 | **Extensões Declarativas Assinadas** | Segurança | Pacotes RSA-SHA256 com fingerprint, confiança no primeiro uso e revogação visual. | ✅ Concluído |
 | **Addon Studio** | Extensibilidade | Criação, sandbox, instalação, exportação e assinatura visual de comandos, skills, conhecimento, templates, aliases, journeys e workflows. | ✅ Concluído |
 | **Portabilidade de Skills** | Extensibilidade | Publicação transacional para quatro CLIs com preview, consentimento, hashes e preservação de conflitos. | ✅ Concluído |
-| **Terminal de alta fidelidade** | Terminal | True color, atributos, alternate screen, bracketed paste, mouse SGR e links OSC 8 sob consentimento. | ✅ Concluído (v2.4.0) |
+| **Terminal de alta fidelidade** | Terminal | True color, atributos, alternate screen, bracketed paste, mouse SGR e links OSC 8 sob consentimento. | ✅ Concluído |
 | **Delphi 12/13 e IDE64** | Compatibilidade | Delphi 12 Win32 e Delphi 13 Win32/IDE64. | ✅ Concluído |
 | **Assistente de threads e PPL** | Concorrência | Detecta riscos e só prepara patches com sincronização VCL, cancelamento e tratamento de exceções validados. | ✅ Concluído |
 | **Retrofit OpenAPI/Swagger** | APIs existentes | Inventaria rotas DEXT e prepara integração Swagger revisável sem recriar o projeto. | ✅ Concluído |


### PR DESCRIPTION
Corrects the public backlog and roadmap after verifying that the deterministic integration and end-to-end platform is already delivered. Also removes stale version wording, fixes outdated documentation paths, and updates documentation tests to validate the current state instead of preserving obsolete backlog text.