### PR TITLE
test: Stabilize Delphi release journeys

### DIFF
--- a/Tests/Web/RadIA.UsageMatrix.test.js
+++ b/Tests/Web/RadIA.UsageMatrix.test.js
@@ -75,6 +75,9 @@ test('release gate composes calculator, opening, and usage tests', () => {
   assert.match(source, /startupRetryUsed/u);
   assert.match(source, /attemptCount/u);
   assert.match(source, /Delphi did not become ready for the smoke test/u);
+  assert.match(source, /The Delphi File menu did not open/u);
+  assert.match(source, /The Delphi file dialog did not open/u);
+  assert.match(source, /Test-RadIAReleaseJourneyRetryable/u);
   assert.match(source, /previousErrorActionPreference/u);
   assert.match(source, /\$ErrorActionPreference = "Continue"/u);
   assert.ok(

--- a/scripts/Test-RadIA.ReleaseUsage.ps1
+++ b/scripts/Test-RadIA.ReleaseUsage.ps1
@@ -141,6 +141,26 @@ $openingResults = @()
 $openingEvidencePath = Join-Path `
     $resolvedEvidenceRoot `
     "project-opening-matrix.json"
+
+function Test-RadIAReleaseJourneyRetryable {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Output
+    )
+
+    $retryableMessages = @(
+        "Delphi did not become ready for the smoke test.",
+        "The Delphi File menu did not open.",
+        "The Delphi file dialog did not open."
+    )
+    foreach ($message in $retryableMessages) {
+        if ($Output.Contains($message)) {
+            return $true
+        }
+    }
+    return $false
+}
+
 foreach ($target in $openingTargets) {
     $arguments = @(
         "-NoProfile",
@@ -167,7 +187,7 @@ foreach ($target in $openingTargets) {
     $startupRetryUsed = $false
     if (
         $exitCode -ne 0 -and
-        $output.Contains("Delphi did not become ready for the smoke test.")
+        (Test-RadIAReleaseJourneyRetryable -Output $output)
     ) {
         $firstAttemptOutput = $output
         Stop-RadIAReleaseIDEProcesses


### PR DESCRIPTION
## Summary

- permits one bounded retry when Delphi startup, File menu, or file dialog automation is transiently unavailable
- preserves the original failure in release evidence
- keeps functional failures blocking and limits attempts to two

## Validation

- ESLint passed
- 49 documentation and usage-matrix tests passed
- release pipeline structure passed