### PR TITLE
docs: Synchronize backlog after release

### DIFF
--- a/Tests/Web/RadIA.Documentation.test.js
+++ b/Tests/Web/RadIA.Documentation.test.js
@@ -1207,17 +1207,17 @@ test('planning and update documentation follow the new separation', () => {
   assert.match(englishHub, /organized by task,[\s\S]*not by release/u);
   assert.doesNotMatch(portugueseBacklog, /\.planning\//u);
   assert.doesNotMatch(englishBacklog, /\.planning\//u);
-  assert.match(portugueseBacklog, /Goal ativo: fechamento determinístico/u);
-  assert.match(englishBacklog, /Active goal: deterministic Delphi experience closure/u);
+  assert.match(portugueseBacklog, /Não há item ou goal aberto/u);
+  assert.match(englishBacklog, /There is no open item or active goal/u);
   assert.ok(
     /^\s*- \[ \]/mu.test(portugueseBacklog) ||
-      /Não há item aberto neste goal/u.test(portugueseBacklog)
+      /Não há item ou goal aberto/u.test(portugueseBacklog)
   );
   assert.ok(
     /^\s*- \[ \]/mu.test(englishBacklog) ||
-      /This goal has no open implementation item/u.test(englishBacklog)
+      /There is no open item or active goal/u.test(englishBacklog)
   );
-  assert.match(portugueseBacklog, /exclui repositório público ou marketplace/u);
-  assert.match(englishBacklog, /excludes a public extension repository or marketplace/u);
+  assert.match(portugueseBacklog, /fora do escopo repositório público ou marketplace/u);
+  assert.match(englishBacklog, /public extension repository or marketplace[\s\S]*remain out of scope/u);
   assert.doesNotMatch(releaseWorkflow, /Output\\Distribution\\stable\.json/u);
 });

--- a/docs/project/backlog.en.md
+++ b/docs/project/backlog.en.md
@@ -3,16 +3,14 @@
 This file contains open work only. History, completed milestones, metrics, and release notes do not
 belong in the backlog.
 
-## Active goal: deterministic Delphi experience closure
+## Current state
 
-Close every actionable difference in the current experience with reproducible evidence, reusing
-existing capabilities before implementing any new infrastructure.
+There is no open item or active goal. The deterministic Delphi experience closure was completed and
+validated by the integrated gates of the published version. New work enters this file only after it
+has an executable scope and defined acceptance criteria.
 
-This goal has no open implementation item. Closure depends only on running the ledger and integrated
-gate against the candidate commit; any failure reopens its corresponding criterion before a release.
-
-The scope excludes a public extension repository or marketplace, C++Builder, Delphi 11, Lazarus,
-GetIt, Embarcadero-exclusive integrations, and replacement of the current WebView.
+A public extension repository or marketplace, C++Builder, Delphi 11, Lazarus, GetIt,
+Embarcadero-exclusive integrations, and replacement of the current WebView remain out of scope.
 
 ## Definition of done for new items
 

--- a/docs/project/backlog.md
+++ b/docs/project/backlog.md
@@ -3,16 +3,14 @@
 Este arquivo contém somente trabalho aberto. Histórico, marcos concluídos, métricas e notas de
 release não pertencem ao backlog.
 
-## Goal ativo: fechamento determinístico da experiência Delphi
+## Estado atual
 
-Encerrar com evidência reproduzível todas as diferenças acionáveis da experiência atual, reutilizando
-as capacidades existentes antes de implementar qualquer nova infraestrutura.
+Não há item ou goal aberto. O fechamento determinístico da experiência Delphi foi concluído e validado
+pelos gates integrados da versão publicada. Novos trabalhos só entram neste arquivo quando possuírem
+escopo executável e critérios de aceitação definidos.
 
-Não há item aberto neste goal. O fechamento depende apenas da execução do ledger e do gate integrado
-no commit candidato; qualquer falha reabre o critério correspondente antes de uma release.
-
-O escopo exclui repositório público ou marketplace de extensões, C++Builder, Delphi 11, Lazarus,
-GetIt, integrações exclusivas da Embarcadero e substituição do WebView atual.
+Permanecem fora do escopo repositório público ou marketplace de extensões, C++Builder, Delphi 11,
+Lazarus, GetIt, integrações exclusivas da Embarcadero e substituição do WebView atual.
 
 ## Definição de concluído para novos itens
 

--- a/docs/project/roadmap.en.md
+++ b/docs/project/roadmap.en.md
@@ -11,12 +11,11 @@ build, test, and debug projects without requiring users to know the internal arc
 evolution must first demonstrate an observable gain for this flow and have verifiable acceptance
 criteria.
 
-## Current goal
+## Next cycle
 
-Deterministically close the remaining actionable differences in knowledge, consent, and engine
-supervision. Each workstream needs a baseline, metric, reproducible
-scenario, and evidence on the same commit before closure. The executable scope is in the
-[backlog](backlog.en.md).
+There is no active goal. The next cycle will be defined only when a proposed improvement has an
+observable gain, baseline, metric, reproducible scenario, and evidence required on the same commit.
+Approved work will be recorded in the [backlog](backlog.en.md) before implementation.
 
 Delphi 11, C++, Lazarus, marketplace work, a public extension repository, WebView replacement, and
 DCU reading remain outside the current direction.

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -11,13 +11,11 @@ compreender, compilar, testar e depurar projetos sem exigir que o usuário conhe
 interna. Evoluções futuras devem primeiro demonstrar ganho observável para esse fluxo e possuir
 critérios de aceitação verificáveis.
 
-## Goal atual
+## Próximo ciclo
 
-Fechar de forma determinística as diferenças acionáveis restantes em conhecimento, consentimento
-e supervisão do motor. Cada frente precisa de baseline,
-métrica, cenário reproduzível e evidência no mesmo commit antes de ser encerrada. O escopo
-executável está no
-[backlog](backlog.md).
+Não existe goal ativo. O próximo ciclo será definido somente quando houver uma melhoria com ganho
+observável, baseline, métrica, cenário reproduzível e evidência exigida no mesmo commit. O trabalho
+aprovado será registrado no [backlog](backlog.md) antes da implementação.
 
 Delphi 11, C++, Lazarus, marketplace, repositório público de extensões, troca do WebView e leitura de
 DCU permanecem fora da direção atual.


### PR DESCRIPTION
## Summary

- marks the deterministic closure goal as completed
- leaves the backlog with no open item or active goal
- aligns the roadmap with the post-release state
- updates documentation regression assertions

## Validation

- 45 documentation checks passed
- ESLint passed
- release pipeline structure passed