### PR TITLE
fix: Route conversational prompts without agent approval

### DIFF
--- a/RadIA.dproj
+++ b/RadIA.dproj
@@ -65,7 +65,7 @@
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.0.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.1.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.1.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     </PropertyGroup>
@@ -73,14 +73,14 @@
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.0.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.1.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.1.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64x)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.0.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.1.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.1.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <BCC_EnableBatchCompilation>true</BCC_EnableBatchCompilation>
     </PropertyGroup>

--- a/RadIA.rc
+++ b/RadIA.rc
@@ -1,6 +1,6 @@
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,17,0,0
-PRODUCTVERSION 2,17,0,0
+FILEVERSION 2,17,1,0
+PRODUCTVERSION 2,17,1,0
 FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -17,12 +17,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Rad IA Open Source Project\0"
             VALUE "FileDescription", "Rad IA - AI Assistant for Delphi IDE\0"
-            VALUE "FileVersion", "2.17.0.0\0"
+            VALUE "FileVersion", "2.17.1.0\0"
             VALUE "InternalName", "RadIA\0"
             VALUE "LegalCopyright", "Copyright (c) 2026\0"
             VALUE "OriginalFilename", "RadIA.bpl\0"
             VALUE "ProductName", "Rad IA\0"
-            VALUE "ProductVersion", "2.17.0.0\0"
+            VALUE "ProductVersion", "2.17.1.0\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/Source/Core/RadIA.Core.IntentRouter.pas
+++ b/Source/Core/RadIA.Core.IntentRouter.pas
@@ -48,6 +48,7 @@ type
       out ARecommendation: TRadIAIntentRecommendation
     ): Boolean; static;
   public
+    class function IsConversationalPrompt(const AInput: string): Boolean; static;
     class function TryRecommend(
       const AInput: string;
       out ARecommendation: TRadIAIntentRecommendation
@@ -179,6 +180,32 @@ begin
     Exit(True);
   end;
   Result := False;
+end;
+
+class function TRadIAIntentRouter.IsConversationalPrompt(
+  const AInput: string
+): Boolean;
+const
+  CConversationalStarts: array[0..24] of string = (
+    'bom dia', 'boa tarde', 'boa noite', 'hello', 'hi ', 'olá', 'ola',
+    'quem ', 'who ', 'o que ', 'what ', 'por que ', 'porque ', 'why ',
+    'como ', 'how ', 'qual ', 'quais ', 'quando ', 'where ', 'onde ',
+    'explique ', 'explain ', 'me fale ', 'tell me '
+  );
+var
+  LPrefix: string;
+  LText: string;
+begin
+  LText := LowerCase(Trim(AInput));
+  if LText.IsEmpty or LText.StartsWith('/') then
+    Exit(False);
+  if LText.EndsWith('?') then
+    Exit(True);
+  for LPrefix in CConversationalStarts do
+    if LText.StartsWith(LPrefix) then
+      Exit(True);
+  Result := SameText(LText, 'hi') or SameText(LText, 'olá') or
+    SameText(LText, 'ola') or SameText(LText, 'hello');
 end;
 
 class function TRadIAIntentRouter.TryRecommend(

--- a/Source/Core/RadIA.Core.Version.pas
+++ b/Source/Core/RadIA.Core.Version.pas
@@ -3,7 +3,7 @@ unit RadIA.Core.Version;
 interface
 
 const
-  CRadIAVersion = '2.17.0';
+  CRadIAVersion = '2.17.1';
 
 function RadIAVersionedCaption(const ACaption: string): string;
 

--- a/Source/UI/RadIA.UI.ChatPresenter.pas
+++ b/Source/UI/RadIA.UI.ChatPresenter.pas
@@ -253,8 +253,10 @@ type
     procedure StartAgentRun(const AObjective: string);
     function TryStartCliAgentRun(
       const AObjective: string;
-      const ASettings: TRadIAResolvedExecutionSettings
+      const ASettings: TRadIAResolvedExecutionSettings;
+      const AConversational: Boolean = False
     ): Boolean;
+    function BuildConversationalCliPrompt(const APromptText: string): string;
     procedure HandleCliAgentFinished(
       const AResult: TRadIACliProcessResult;
       const ADefinition: TRadIACliDefinition;
@@ -492,6 +494,7 @@ type
 
     {$IFDEF TESTS}
     function TestPreProcessPrompt(const APromptText: string): string;
+    function TestBuildConversationalCliPrompt(const APromptText: string): string;
     {$ENDIF}
 
     property SessionManager: TRadIASessionManager read FSessionManager;
@@ -1666,6 +1669,7 @@ end;
 
 procedure TRadIAChatPresenter.SendPromptText(const APromptText: string);
 var
+  LConversational: Boolean;
   LEffectiveSettings: TRadIAResolvedExecutionSettings;
   LPreflightMessage: string;
   LProcessed: string;
@@ -1674,6 +1678,7 @@ begin
     Exit;
 
   EnsureJourneyProjectBoundary;
+  LConversational := TRadIAIntentRouter.IsConversationalPrompt(APromptText);
   LProcessed := PreProcessPrompt(APromptText);
   LEffectiveSettings := ResolveEffectiveExecutionSettings;
   if not CheckChatPreflight(LEffectiveSettings, LPreflightMessage) then
@@ -1682,12 +1687,12 @@ begin
     Exit;
   end;
   PostToWebView('add_message', 'user', APromptText);
-  if FAgentModeEnabled then
+  if FAgentModeEnabled and not LConversational then
   begin
     StartAgentRun(LProcessed);
     Exit;
   end;
-  if TryStartCliAgentRun(LProcessed, LEffectiveSettings) then
+  if TryStartCliAgentRun(LProcessed, LEffectiveSettings, LConversational) then
     Exit;
   SendPromptToAI(LProcessed);
 end;
@@ -4531,9 +4536,22 @@ begin
   end;
 end;
 
+function TRadIAChatPresenter.BuildConversationalCliPrompt(
+  const APromptText: string
+): string;
+begin
+  Result :=
+    'You are RadIA, the AI assistant integrated into RAD Studio for Delphi development. ' +
+    'Answer the user directly in the user''s language. This is a conversational request: ' +
+    'do not inspect files, run commands, create a plan, or describe yourself as the CLI executor.' +
+    sLineBreak + sLineBreak +
+    'User message:' + sLineBreak + APromptText;
+end;
+
 function TRadIAChatPresenter.TryStartCliAgentRun(
   const AObjective: string;
-  const ASettings: TRadIAResolvedExecutionSettings
+  const ASettings: TRadIAResolvedExecutionSettings;
+  const AConversational: Boolean
 ): Boolean;
 var
   LDefinition: TRadIACliDefinition;
@@ -4541,10 +4559,12 @@ var
   LExternalSessionId: string;
   LGuard: IRadIALifecycleGuard;
   LInvocation: TRadIACliInvocation;
+  LPrompt: string;
   LProject: TRadIAProjectSnapshot;
   LSession: TSessionInfo;
   LSessionId: string;
   LTimeoutMs: Integer;
+  LReasoningEffort: string;
   LUserMessage: IRadIAChatMessage;
   LWorkingDirectory: string;
 begin
@@ -4586,17 +4606,25 @@ begin
 
   LExternalSessionId := '';
   LSessionId := FSessionManager.ActiveSessionId;
-  if FSessionManager.TryGetSession(LSessionId, LSession) and
+  if not AConversational and
+    FSessionManager.TryGetSession(LSessionId, LSession) and
     SameText(LSession.CliClientId, LDefinition.Id) and
     SameText(LSession.CliWorkingDirectory, LWorkingDirectory) then
     LExternalSessionId := LSession.CliExternalSessionId;
+  LPrompt := AObjective;
+  LReasoningEffort := FAgentExecutorSettings.Load.ReasoningEffort;
+  if AConversational then
+  begin
+    LPrompt := BuildConversationalCliPrompt(AObjective);
+    LReasoningEffort := 'low';
+  end;
   LInvocation := TRadIACliInvocationBuilder.Build(
     LDefinition,
     LDetection.ExecutablePath,
-    AObjective,
+    LPrompt,
     LWorkingDirectory,
     LExternalSessionId,
-    FAgentExecutorSettings.Load.ReasoningEffort
+    LReasoningEffort
   );
   LUserMessage := TRadIAChatMessage.CreateMessage(
     mrUser,
@@ -5618,6 +5646,13 @@ end;
 function TRadIAChatPresenter.TestPreProcessPrompt(const APromptText: string): string;
 begin
   Result := PreProcessPrompt(APromptText);
+end;
+
+function TRadIAChatPresenter.TestBuildConversationalCliPrompt(
+  const APromptText: string
+): string;
+begin
+  Result := BuildConversationalCliPrompt(APromptText);
 end;
 {$ENDIF}
 

--- a/Tests/Source/RadIA.Tests.ChatPresenter.pas
+++ b/Tests/Source/RadIA.Tests.ChatPresenter.pas
@@ -216,6 +216,10 @@ type
     [Test]
     procedure TestGlobalPromptWithCommandLineBreakUsesTemplate;
     [Test]
+    procedure TestConversationalCliPromptPreservesRadIAIdentity;
+    [Test]
+    procedure TestConversationalQuestionBypassesAgentPlan;
+    [Test]
     procedure TestDeclarativeExtensionCommandReloadsWithoutRestart;
     [Test]
     procedure TestDeclarativeExtensionAppearsInSlashCatalog;
@@ -1696,6 +1700,33 @@ begin
   Assert.IsTrue(LProcessed.StartsWith('Explain this Delphi Pascal code briefly.', True), LProcessed);
   Assert.IsFalse(LProcessed.StartsWith('Review the following Delphi Pascal code block', True), LProcessed);
   Assert.IsTrue(LProcessed.Contains('TForm1 = class(TForm)'));
+end;
+
+procedure TTestChatPresenter.TestConversationalCliPromptPreservesRadIAIdentity;
+var
+  LPrompt: string;
+begin
+  LPrompt := FPresenter.TestBuildConversationalCliPrompt('Quem é você?');
+
+  Assert.Contains(LPrompt, 'You are RadIA');
+  Assert.Contains(LPrompt, 'do not inspect files');
+  Assert.Contains(LPrompt, 'do not inspect files, run commands, create a plan');
+  Assert.Contains(LPrompt, 'Quem é você?');
+end;
+
+procedure TTestChatPresenter.TestConversationalQuestionBypassesAgentPlan;
+begin
+  FPresenter.Initialize('C:\mock\web');
+  FPresenter.WebViewReady := True;
+
+  FPresenter.SendPromptText('Quem é você?');
+  DrainQueuedCalls;
+
+  Assert.IsTrue(FMockView.RequestStateInProgress);
+  Assert.DoesNotContain(FMockView.PostedMessages.Text, '"action":"agent_state"');
+  Assert.DoesNotContain(FMockView.PostedMessages.Text, '"status":"awaitingApproval"');
+
+  FPresenter.CancelRequest;
 end;
 
 procedure TTestChatPresenter.TestSlashCommandUsesProvidedCodeBlock;

--- a/Tests/Source/RadIA.Tests.IntentRouter.pas
+++ b/Tests/Source/RadIA.Tests.IntentRouter.pas
@@ -20,6 +20,8 @@ type
     [Test]
     procedure LeavesOrdinaryChatAndExplicitCommandsUntouched;
     [Test]
+    procedure RoutesConversationalQuestionsDirectlyToChat;
+    [Test]
     procedure RoutesBeginnerPromptMatrix;
   end;
 
@@ -145,6 +147,30 @@ begin
     Assert.IsTrue(TRadIAIntentRouter.TryRecommend(LPrompt, LRecommendation), LPrompt);
     Assert.AreEqual(rikDiagnose, LRecommendation.Intent, LPrompt);
   end;
+end;
+
+procedure TTestRadIAIntentRouter.RoutesConversationalQuestionsDirectlyToChat;
+begin
+  Assert.IsTrue(TRadIAIntentRouter.IsConversationalPrompt('Quem é você?'));
+  Assert.IsTrue(TRadIAIntentRouter.IsConversationalPrompt('O que é FireDAC?'));
+  Assert.IsTrue(TRadIAIntentRouter.IsConversationalPrompt(
+    'Como funcionam transações no Delphi?'
+  ));
+  Assert.IsTrue(TRadIAIntentRouter.IsConversationalPrompt(
+    'Explique a diferença entre commit e rollback'
+  ));
+  Assert.IsTrue(TRadIAIntentRouter.IsConversationalPrompt(
+    'Você conhece o componente TFDMemTable?'
+  ));
+  Assert.IsFalse(TRadIAIntentRouter.IsConversationalPrompt(
+    'Audite o uso de FireDAC deste projeto'
+  ));
+  Assert.IsFalse(TRadIAIntentRouter.IsConversationalPrompt(
+    'Corrija o erro de compilação deste projeto'
+  ));
+  Assert.IsFalse(TRadIAIntentRouter.IsConversationalPrompt(
+    '/agent run inspect the active project'
+  ));
 end;
 
 initialization

--- a/docs/guides/mcp_integration_guide.en.md
+++ b/docs/guides/mcp_integration_guide.en.md
@@ -195,7 +195,7 @@ For reproducible automation, prefer `mcp.<pid>.json`.
 1. Open Delphi and a project.
 2. Confirm that `mcp.<pid>.json` exists.
 3. Start or reload the MCP server in the client.
-4. Verify that `initialize` reports RadIA `2.17.0`.
+4. Verify that `initialize` reports RadIA `2.17.1`.
 5. Call `tools/list`.
 6. Call `GetIDEState` and `GetActiveProject`.
 7. Test mutable consent only in a disposable project.

--- a/docs/guides/mcp_integration_guide.md
+++ b/docs/guides/mcp_integration_guide.md
@@ -215,7 +215,7 @@ Para automação reproduzível, prefira sempre `mcp.<pid>.json`.
 1. Abra o Delphi e um projeto.
 2. Confirme que `mcp.<pid>.json` foi criado.
 3. Inicie ou recarregue o servidor no cliente MCP.
-4. Verifique que `initialize` retorna RadIA `2.17.0`.
+4. Verifique que `initialize` retorna RadIA `2.17.1`.
 5. Execute `tools/list`.
 6. Chame `GetIDEState` e `GetActiveProject`.
 7. Para testar consentimento, use uma tool mutável somente em um projeto descartável.

--- a/docs/guides/user_manual.en.md
+++ b/docs/guides/user_manual.en.md
@@ -1,4 +1,4 @@
-# Complete RadIA 2.17.0 user manual
+# Complete RadIA 2.17.1 user manual
 
 > Use `/help` to compare Chat, Agent, CLI, and MCP. When a plan awaits approval, select
 > **Approve plan** or type `/agent resume`.
@@ -21,6 +21,11 @@ Type `/help` in chat for capabilities, primary commands, and guide links. Links 
 browser. Journeys started without every required value enter conversational intake and retain each
 answer until execution or `/journey cancel`.
 
+Direct questions such as “who are you?” or “what is FireDAC?” stay in Chat even while the Agent
+button is enabled. They neither create a plan nor request approval. If Chat uses a CLI executor,
+the question receives an isolated low-effort conversational run and does not inherit the previous
+agent task session.
+
 After installing the package for the intended IDE architecture, open Delphi and dock the RadIA
 panel. Configure a provider under `Tools > Options > Rad IA`, select a model, create a session, and
 send a prompt with `Ctrl + Enter`.
@@ -30,7 +35,7 @@ the next time Delphi opens. If the panel is closed before exiting, it remains cl
 session; use `Tools > RadIA > Chat` to open it again.
 
 The chat panel caption and primary RadIA windows show the loaded version, for example
-`Rad IA Chat v2.17.0`, so support can confirm the installed build quickly.
+`Rad IA Chat v2.17.1`, so support can confirm the installed build quickly.
 
 Supported credentials are protected locally with Windows DPAPI. Ollama and LM Studio can run
 locally. See the [installation guide](../getting-started/install_config.en.md).

--- a/docs/guides/user_manual.md
+++ b/docs/guides/user_manual.md
@@ -1,4 +1,4 @@
-# Manual completo do RadIA 2.17.0
+# Manual completo do RadIA 2.17.1
 
 > Para comparar Chat, Agent, CLI e MCP, use `/help`. Quando um plano aguardar aprovação, clique em
 > **Approve plan** ou digite `/agent resume`.
@@ -28,6 +28,11 @@ Digite `/help` no chat para consultar capacidades, comandos principais e links p
 links são abertos no navegador padrão. Jornadas iniciadas sem todos os dados entram em coleta
 conversacional e mantêm cada resposta até a execução ou até `/journey cancel`.
 
+Perguntas diretas, como “quem é você?” ou “o que é FireDAC?”, seguem pelo Chat mesmo quando o botão
+Agent está ativo. Elas não criam plano nem pedem aprovação. Se o Chat usa um executor CLI, a
+pergunta recebe uma execução conversacional isolada e de esforço baixo, sem herdar a sessão da
+tarefa agentiva anterior.
+
 ### 2.1 Abrir o painel
 
 Depois de instalar o pacote correspondente à IDE, abra o Delphi. O RadIA é carregado como package
@@ -39,7 +44,7 @@ são restaurados na próxima abertura do Delphi. Se o painel for fechado antes d
 fechado na sessão seguinte; use `Tools > RadIA > Chat` para abri-lo novamente.
 
 O caption do painel de chat e das janelas principais do RadIA mostra a versão carregada, por exemplo
-`Rad IA Chat v2.17.0`, para facilitar suporte e conferência de instalação.
+`Rad IA Chat v2.17.1`, para facilitar suporte e conferência de instalação.
 
 Se o painel ou package não aparecer:
 

--- a/docs/reference/capabilities.en.md
+++ b/docs/reference/capabilities.en.md
@@ -42,6 +42,10 @@ and IDE64 rules therefore enter the context with stable, queryable citations.
 | Extensions | Visual creation, sandbox, install, export, signing, and management plus a versioned tool API protected by the policy pipeline. |
 | Declarative extensions | Hot-reloaded commands, skills, journeys, knowledge, references, templates, aliases, and audited workflows with transactional package resources. |
 | Skill portability | Project-scoped publication to four CLIs with preview, central consent, ownership hashes, rollback, and conflict preservation. |
+
+Ordinary questions remain in Chat and do not start a tool loop or require plan approval. With a CLI
+transport, RadIA uses an isolated low-effort conversational run instead of resuming a previous
+agent task.
 | FireDAC inventory | Locate bounded PAS/DFM components and relationships without executing SQL or returning credential values. |
 | Local SQLite | Discover tables, views, and columns, then preview one consented read-only query with bounded, redacted grid and CSV output. |
 

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -245,7 +245,9 @@ O modo agente oferece:
 - limites de passos, tokens, tempo, custo e repetição;
 - build e validação como parte do objetivo quando solicitados.
 
-Perguntas comuns continuam como chat e não iniciam automaticamente um loop de ferramentas.
+Perguntas comuns continuam como chat e não iniciam automaticamente um loop de ferramentas. Quando
+o transporte selecionado é um CLI, o RadIA usa uma execução conversacional isolada, com esforço
+baixo e sem retomar a sessão de uma tarefa agentiva anterior.
 
 Consulte [Manual completo](../guides/user_manual.md), [Custos do agente](agent_pricing.md) e
 [Compactação de resultados](../guides/agent_result_compaction.md).

--- a/docs/reference/cli_capability_matrix.en.md
+++ b/docs/reference/cli_capability_matrix.en.md
@@ -15,7 +15,7 @@
 
 ## Current matrix
 
-| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.0 use |
+| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.1 use |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Yes, JSONL | Structured event | `exec resume <id>` | Yes | Yes | Not declared | New execution per message |
 | Claude Code | Yes, stream JSON | Structured event | `--resume <id>` | Yes | Yes | Not declared | New execution per message |

--- a/docs/reference/cli_capability_matrix.md
+++ b/docs/reference/cli_capability_matrix.md
@@ -15,7 +15,7 @@
 
 ## Matriz atual
 
-| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.0 |
+| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.1 |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Sim, JSONL | Evento estruturado | `exec resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |
 | Claude Code | Sim, stream JSON | Evento estruturado | `--resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radia-plugin",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Rad IA - AI Assistant for Delphi IDE",
   "main": "eslint.config.js",
   "scripts": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # SonarQube Project Configuration
 sonar.projectKey=radia
 sonar.projectName=radia
-sonar.projectVersion=2.17.0
+sonar.projectVersion=2.17.1
 
 # Path to the source directories
 sonar.sources=Source


### PR DESCRIPTION
## Resumo

- mantém perguntas conversacionais no Chat mesmo com Agent habilitado;
- impede plano e aprovação para perguntas simples;
- isola sessões CLI conversacionais e usa esforço baixo;
- preserva a identidade do RadIA;
- atualiza a versão para 2.17.1 e a documentação em português e inglês.

## Validação

- gate completo de release aprovado no Delphi 12 e 13;
- 1.401 testes DUnitX + 8 testes externos aprovados em cada versão;
- matriz de integração, E2E e projetos gerados aprovada;
- SonarQube Quality Gate aprovado: 0 issues, cobertura global 84,6%;
- instalador visual validado: SHA-256 9AE9BCAAAA9336DC9662129757707354A3C08F19415AC063C771BEBA9AFCB117.