### PR TITLE
fix: Restore dockable chat window state

### DIFF
--- a/RadIA.dproj
+++ b/RadIA.dproj
@@ -65,7 +65,7 @@
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.1.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.1.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.2.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.2.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     </PropertyGroup>
@@ -73,14 +73,14 @@
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.1.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.1.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.2.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.2.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64x)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.1.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.1.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.2.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.2.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <BCC_EnableBatchCompilation>true</BCC_EnableBatchCompilation>
     </PropertyGroup>

--- a/RadIA.rc
+++ b/RadIA.rc
@@ -1,6 +1,6 @@
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,17,1,0
-PRODUCTVERSION 2,17,1,0
+FILEVERSION 2,17,2,0
+PRODUCTVERSION 2,17,2,0
 FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -17,12 +17,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Rad IA Open Source Project\0"
             VALUE "FileDescription", "Rad IA - AI Assistant for Delphi IDE\0"
-            VALUE "FileVersion", "2.17.1.0\0"
+            VALUE "FileVersion", "2.17.2.0\0"
             VALUE "InternalName", "RadIA\0"
             VALUE "LegalCopyright", "Copyright (c) 2026\0"
             VALUE "OriginalFilename", "RadIA.bpl\0"
             VALUE "ProductName", "Rad IA\0"
-            VALUE "ProductVersion", "2.17.1.0\0"
+            VALUE "ProductVersion", "2.17.2.0\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/Source/Core/RadIA.Core.Version.pas
+++ b/Source/Core/RadIA.Core.Version.pas
@@ -3,7 +3,7 @@ unit RadIA.Core.Version;
 interface
 
 const
-  CRadIAVersion = '2.17.1';
+  CRadIAVersion = '2.17.2';
 
 function RadIAVersionedCaption(const ACaption: string): string;
 

--- a/Source/Integration/RadIA.OTA.DockableForm.pas
+++ b/Source/Integration/RadIA.OTA.DockableForm.pas
@@ -17,10 +17,13 @@ uses
   System.IniFiles,
   System.SysUtils,
   System.Win.Registry,
+  Winapi.Messages,
   Winapi.Windows,
   DesignIntf,
   Vcl.ActnList,
   Vcl.ComCtrls,
+  Vcl.Controls,
+  Vcl.ExtCtrls,
   Vcl.Forms,
   Vcl.ImgList,
   Vcl.Menus,
@@ -38,6 +41,8 @@ type
   TRadIADockableFormObserver = class(TComponent)
   private
     FHost: TRadIACustomDockableForm;
+    FTimer: TTimer;
+    procedure TimerEvent(Sender: TObject);
   protected
     procedure Notification(AComponent: TComponent; Operation: TOperation); override;
   public
@@ -55,17 +60,22 @@ type
     FDefaultWidth: Integer;
     FDefaultHeight: Integer;
     FHasSavedWindowState: Boolean;
-    FPreviousOnShow: TNotifyEvent;
-    FPreviousOnClose: TCloseEvent;
+    FObservedBounds: TRect;
+    FObservedStateInitialized: Boolean;
+    FObservedVisible: Boolean;
+    FPreviousWindowProc: TWndMethod;
     procedure ApplyIDETheme;
     procedure ApplyWindowIdentity;
     procedure AttachNativeForm(AForm: TCustomForm);
     procedure DetachNativeForm;
     procedure EnsureFrameContent;
-    procedure FormClose(Sender: TObject; var Action: TCloseAction);
+    procedure FormWindowProc(var AMessage: TMessage);
     procedure FormRemoved;
-    procedure FormShow(Sender: TObject);
+    procedure LoadPersistedBounds;
+    procedure PersistCurrentState;
+    procedure SavePersistedBounds;
     procedure SaveVisibility(const AVisible: Boolean);
+    procedure SynchronizeCurrentState;
   public
     constructor Create(
       const ACaption: string;
@@ -224,6 +234,10 @@ constructor TRadIADockableFormObserver.Create(AHost: TRadIACustomDockableForm);
 begin
   inherited Create(nil);
   FHost := AHost;
+  FTimer := TTimer.Create(Self);
+  FTimer.Interval := 500;
+  FTimer.OnTimer := TimerEvent;
+  FTimer.Enabled := True;
 end;
 
 procedure TRadIADockableFormObserver.Notification(
@@ -235,6 +249,12 @@ begin
   if (Operation = opRemove) and Assigned(FHost) and
     (AComponent = FHost.FForm) then
     FHost.FormRemoved;
+end;
+
+procedure TRadIADockableFormObserver.TimerEvent(Sender: TObject);
+begin
+  if Assigned(FHost) and not GIsShuttingDown then
+    FHost.SynchronizeCurrentState;
 end;
 
 { TRadIACustomDockableForm }
@@ -266,22 +286,49 @@ end;
 procedure PrepareDockableFormsForShutdown;
 begin
   if Assigned(GRadIADockableFormHost) then
+  begin
+    GRadIADockableFormHost.PersistCurrentState;
     GRadIADockableFormHost.ReleaseForm;
+  end;
   if Assigned(GRadIATerminalDockableFormHost) then
+  begin
+    GRadIATerminalDockableFormHost.PersistCurrentState;
     GRadIATerminalDockableFormHost.ReleaseForm;
+  end;
+end;
+
+procedure RestoreDockableFormVisibility;
+var
+  LRegistry: TRegistry;
+  LServices: IOTAServices;
+  LVisible: Boolean;
+begin
+  LVisible := False;
+  if not Supports(BorlandIDEServices, IOTAServices, LServices) then
+    Exit;
+  LRegistry := TRegistry.Create;
+  try
+    LRegistry.RootKey := HKEY_CURRENT_USER;
+    if LRegistry.OpenKeyReadOnly(
+      LServices.GetBaseRegistryKey + '\RadIA'
+    ) and LRegistry.ValueExists('WindowVisible') then
+      LVisible := LRegistry.ReadBool('WindowVisible');
+  finally
+    LRegistry.Free;
+  end;
+  if Assigned(GRadIADockableFormHost) and LVisible then
+    GRadIADockableFormHost.Show;
 end;
 
 procedure TRadIACustomDockableForm.DetachNativeForm;
 begin
   if not Assigned(FForm) then
     Exit;
-  TRadIAAccessibleCustomForm(FForm).OnShow := FPreviousOnShow;
-  TRadIAAccessibleCustomForm(FForm).OnClose := FPreviousOnClose;
+  TRadIAAccessibleCustomForm(FForm).WindowProc := FPreviousWindowProc;
   FForm.RemoveFreeNotification(FObserver);
   FForm := nil;
   FFrame := nil;
-  FPreviousOnShow := nil;
-  FPreviousOnClose := nil;
+  FPreviousWindowProc := nil;
 end;
 
 procedure TRadIACustomDockableForm.ApplyIDETheme;
@@ -341,49 +388,44 @@ end;
 
 procedure TRadIACustomDockableForm.FormRemoved;
 begin
+  if Assigned(FForm) and not GIsShuttingDown then
+  begin
+    SavePersistedBounds;
+    SaveVisibility(False);
+  end;
   FForm := nil;
   FFrame := nil;
+  FPreviousWindowProc := nil;
 end;
 
-procedure TRadIACustomDockableForm.FormClose(
-  Sender: TObject;
-  var Action: TCloseAction
-);
-begin
-  SaveVisibility(False);
-  if Assigned(FPreviousOnClose) then
-    FPreviousOnClose(Sender, Action);
-end;
-
-procedure TRadIACustomDockableForm.FormShow(Sender: TObject);
-begin
-  SaveVisibility(True);
-  if Assigned(FPreviousOnShow) then
-    FPreviousOnShow(Sender);
-end;
-
-procedure RestoreDockableFormVisibility;
+procedure TRadIACustomDockableForm.SynchronizeCurrentState;
 var
-  LRegistry: TRegistry;
-  LServices: IOTAServices;
+  LBounds: TRect;
   LVisible: Boolean;
 begin
-  LVisible := False;
-  if not Supports(BorlandIDEServices, IOTAServices, LServices) then
+  if not Assigned(FForm) then
     Exit;
-  LRegistry := TRegistry.Create;
-  try
-    LRegistry.RootKey := HKEY_CURRENT_USER;
-    if LRegistry.OpenKeyReadOnly(
-      LServices.GetBaseRegistryKey + '\RadIA'
-    ) and LRegistry.ValueExists('WindowVisible') then
-      LVisible := LRegistry.ReadBool('WindowVisible');
-  finally
-    LRegistry.Free;
-  end;
+  LBounds := FForm.BoundsRect;
+  LVisible := FForm.Visible;
+  if not FObservedStateInitialized or (LVisible <> FObservedVisible) then
+    SaveVisibility(LVisible);
+  if not FObservedStateInitialized or not EqualRect(LBounds, FObservedBounds) then
+    SavePersistedBounds;
+  FObservedBounds := LBounds;
+  FObservedVisible := LVisible;
+  FObservedStateInitialized := True;
+end;
 
-  if Assigned(GRadIADockableFormHost) and LVisible then
-    GRadIADockableFormHost.Show;
+procedure TRadIACustomDockableForm.FormWindowProc(var AMessage: TMessage);
+begin
+  if Assigned(FPreviousWindowProc) then
+    FPreviousWindowProc(AMessage);
+  if not Assigned(FForm) then
+    Exit;
+  if AMessage.Msg = CM_SHOWINGCHANGED then
+    SaveVisibility(FForm.Visible)
+  else if AMessage.Msg = WM_EXITSIZEMOVE then
+    SavePersistedBounds;
 end;
 
 procedure TRadIACustomDockableForm.FrameCreated(AFrame: TCustomFrame);
@@ -401,10 +443,8 @@ begin
   FForm := AForm;
   FForm.FreeNotification(FObserver);
   FForm.Caption := GetCaption;
-  FPreviousOnShow := TRadIAAccessibleCustomForm(FForm).OnShow;
-  FPreviousOnClose := TRadIAAccessibleCustomForm(FForm).OnClose;
-  TRadIAAccessibleCustomForm(FForm).OnShow := FormShow;
-  TRadIAAccessibleCustomForm(FForm).OnClose := FormClose;
+  FPreviousWindowProc := TRadIAAccessibleCustomForm(FForm).WindowProc;
+  TRadIAAccessibleCustomForm(FForm).WindowProc := FormWindowProc;
   ApplyWindowIdentity;
 end;
 
@@ -454,6 +494,73 @@ procedure TRadIACustomDockableForm.LoadWindowState(
 );
 begin
   FHasSavedWindowState := ADesktop.SectionExists(ASection);
+  TLogger.Log(
+    'Desktop state loaded for ' + FIdentifier + ': section=' + ASection +
+    ', source=' + ADesktop.ClassName +
+    ', exists=' + BoolToStr(FHasSavedWindowState, True) + '.',
+    'DockableForm'
+  );
+end;
+
+procedure TRadIACustomDockableForm.LoadPersistedBounds;
+var
+  LRegistry: TRegistry;
+  LServices: IOTAServices;
+begin
+  if FIdentifier <> 'RadIADockableForm' then
+    Exit;
+  if not Supports(BorlandIDEServices, IOTAServices, LServices) then
+    Exit;
+  LRegistry := TRegistry.Create;
+  try
+    LRegistry.RootKey := HKEY_CURRENT_USER;
+    if not LRegistry.OpenKeyReadOnly(LServices.GetBaseRegistryKey + '\RadIA') then
+      Exit;
+    if LRegistry.ValueExists('WindowWidth') then
+      FForm.Width := LRegistry.ReadInteger('WindowWidth');
+    if LRegistry.ValueExists('WindowHeight') then
+      FForm.Height := LRegistry.ReadInteger('WindowHeight');
+    if LRegistry.ValueExists('WindowLeft') then
+      FForm.Left := LRegistry.ReadInteger('WindowLeft');
+    if LRegistry.ValueExists('WindowTop') then
+      FForm.Top := LRegistry.ReadInteger('WindowTop');
+  finally
+    LRegistry.Free;
+  end;
+end;
+
+procedure TRadIACustomDockableForm.PersistCurrentState;
+begin
+  if not Assigned(FForm) then
+    Exit;
+  SaveVisibility(FForm.Visible);
+  SavePersistedBounds;
+end;
+
+procedure TRadIACustomDockableForm.SavePersistedBounds;
+var
+  LRegistry: TRegistry;
+  LServices: IOTAServices;
+begin
+  if (FIdentifier <> 'RadIADockableForm') or not Assigned(FForm) then
+    Exit;
+  if not TRadIAAccessibleCustomForm(FForm).Floating then
+    Exit;
+  if not Supports(BorlandIDEServices, IOTAServices, LServices) then
+    Exit;
+  LRegistry := TRegistry.Create;
+  try
+    LRegistry.RootKey := HKEY_CURRENT_USER;
+    if LRegistry.OpenKey(LServices.GetBaseRegistryKey + '\RadIA', True) then
+    begin
+      LRegistry.WriteInteger('WindowWidth', FForm.Width);
+      LRegistry.WriteInteger('WindowHeight', FForm.Height);
+      LRegistry.WriteInteger('WindowLeft', FForm.Left);
+      LRegistry.WriteInteger('WindowTop', FForm.Top);
+    end;
+  finally
+    LRegistry.Free;
+  end;
 end;
 
 procedure TRadIACustomDockableForm.SaveVisibility(const AVisible: Boolean);
@@ -465,14 +572,10 @@ begin
     Exit;
   if not Supports(BorlandIDEServices, IOTAServices, LServices) then
     Exit;
-
   LRegistry := TRegistry.Create;
   try
     LRegistry.RootKey := HKEY_CURRENT_USER;
-    if LRegistry.OpenKey(
-      LServices.GetBaseRegistryKey + '\RadIA',
-      True
-    ) then
+    if LRegistry.OpenKey(LServices.GetBaseRegistryKey + '\RadIA', True) then
       LRegistry.WriteBool('WindowVisible', AVisible);
   finally
     LRegistry.Free;
@@ -492,7 +595,12 @@ procedure TRadIACustomDockableForm.SaveWindowState(
   AIsProject: Boolean
 );
 begin
-  // The native IDE host persists its standard docking state.
+  TLogger.Log(
+    'Desktop state saved for ' + FIdentifier + ': section=' + ASection +
+    ', source=' + ADesktop.ClassName +
+    ', project=' + BoolToStr(AIsProject, True) + '.',
+    'DockableForm'
+  );
 end;
 
 procedure TRadIACustomDockableForm.Show;
@@ -524,6 +632,7 @@ begin
     begin
       FForm.Width := FDefaultWidth;
       FForm.Height := FDefaultHeight;
+      LoadPersistedBounds;
     end;
     TLogger.Log(
       'Native form created for ' + FIdentifier + ': ' + FForm.ClassName + '.',

--- a/Source/Integration/RadIA.OTA.Register.pas
+++ b/Source/Integration/RadIA.OTA.Register.pas
@@ -371,6 +371,10 @@ begin
     TRadIAConfig.SetBaseRegistryPath(LOTAServices.GetBaseRegistryKey + '\RadIA');
   end;
 
+  {$IFNDEF TESTS}
+  RadIA.OTA.DockableForm.RegisterDockableForm;
+  {$ENDIF}
+
   if Supports(BorlandIDEServices, IOTAWizardServices, LWizardServices) then
   begin
     LogDebug('IOTAWizardServices supported');
@@ -410,10 +414,6 @@ begin
 
   FOptionsPages := TInterfaceList.Create;
   FApplicationEvents := TRadIAApplicationShutdownObserver.Create;
-
-  {$IFNDEF TESTS}
-  RadIA.OTA.DockableForm.RegisterDockableForm;
-  {$ENDIF}
 
   { Register custom forms in IDE Theming Services }
   if Supports(BorlandIDEServices, IOTAIDEThemingServices, LThemingServices) then

--- a/Tests/Web/RadIA.DockableWindowState.test.js
+++ b/Tests/Web/RadIA.DockableWindowState.test.js
@@ -12,6 +12,10 @@ const register = fs.readFileSync(
   path.join(repositoryRoot, 'Source', 'Integration', 'RadIA.OTA.Register.pas'),
   'utf8'
 );
+const ideSmoke = fs.readFileSync(
+  path.join(repositoryRoot, 'scripts', 'Test-RadIA.IDESmoke.ps1'),
+  'utf8'
+);
 
 test('desktop-created native form is attached instead of duplicated', () => {
   assert.match(dockableForm, /FrameCreated[\s\S]*AttachNativeForm\(GetParentForm\(AFrame\)\)/u);
@@ -26,13 +30,56 @@ test('saved desktop geometry is not overwritten by default dimensions', () => {
   );
 });
 
-test('visibility follows actual native form show and close events', () => {
-  assert.doesNotMatch(register, /RestoreWindowVisibility/u);
+test('native desktop owns docking while actual window messages persist user intent', () => {
   assert.match(
     dockableForm,
-    /OnShow := FormShow;[\s\S]*OnClose := FormClose/u
+    /AMessage\.Msg = CM_SHOWINGCHANGED[\s\S]*SaveVisibility\(FForm\.Visible\)/u
   );
-  assert.match(dockableForm, /FormShow[\s\S]*SaveVisibility\(True\)/u);
-  assert.match(dockableForm, /FormClose[\s\S]*SaveVisibility\(False\)/u);
+  assert.match(
+    dockableForm,
+    /AMessage\.Msg = WM_EXITSIZEMOVE[\s\S]*SavePersistedBounds/u
+  );
+  assert.match(
+    dockableForm,
+    /PrepareDockableFormsForShutdown[\s\S]*PersistCurrentState[\s\S]*ReleaseForm/u
+  );
   assert.match(register, /DockableForm\.RestoreDockableFormVisibility/u);
+  assert.match(
+    dockableForm,
+    /if not FHasSavedWindowState then[\s\S]*LoadPersistedBounds/u
+  );
+});
+
+test('native host state is observed even when OTA suppresses form messages', () => {
+  assert.match(
+    dockableForm,
+    /FTimer\.Interval := 500;[\s\S]*FTimer\.OnTimer := TimerEvent/u
+  );
+  assert.match(
+    dockableForm,
+    /SynchronizeCurrentState[\s\S]*FForm\.BoundsRect[\s\S]*FForm\.Visible/u
+  );
+  assert.match(
+    dockableForm,
+    /procedure TRadIACustomDockableForm\.FormRemoved;[\s\S]*SavePersistedBounds;[\s\S]*SaveVisibility\(False\)/u
+  );
+});
+
+test('dockable forms register directly during the package Register procedure', () => {
+  assert.match(
+    register,
+    /procedure Register;[\s\S]*DockableForm\.RegisterDockableForm;[\s\S]*LWizardServices\.AddWizard/u
+  );
+  assert.doesNotMatch(
+    register,
+    /constructor TRadIAWizard\.Create;[\s\S]*DockableForm\.RegisterDockableForm/u
+  );
+});
+
+test('real IDE smoke rejects automatic chat opening from a hidden state', () => {
+  assert.match(ideSmoke, /\[switch\]\$ExpectDockHidden/u);
+  assert.match(
+    ideSmoke,
+    /if \(\$ExpectDockHidden\)[\s\S]*Get-RadIADockInfo[\s\S]*opened despite the persisted hidden state/u
+  );
 });

--- a/Tests/Web/RadIA.ExecutionRouteCopy.test.js
+++ b/Tests/Web/RadIA.ExecutionRouteCopy.test.js
@@ -50,7 +50,10 @@ test('chat exposes the effective route independently from agent mode', () => {
   assert.match(chatJs, /RTK saved/u);
   assert.match(chatJs, /action: 'set_agent_executor'/u);
   assert.match(presenter, /procedure TRadIAChatPresenter\.SetAgentExecutor/u);
-  assert.match(presenter, /if FAgentModeEnabled then[\s\S]*StartAgentRun\(LProcessed\)/u);
+  assert.match(
+    presenter,
+    /if FAgentModeEnabled and not LConversational then[\s\S]*StartAgentRun\(LProcessed\)/u
+  );
   assert.match(
     presenter,
     /if TryStartCliAgentRun\(LProcessed, LEffectiveSettings\) then/u

--- a/Tests/Web/RadIA.WebViewLifecycle.test.js
+++ b/Tests/Web/RadIA.WebViewLifecycle.test.js
@@ -50,8 +50,6 @@ test('chat uses bounded WebView recovery and shutdown-safe callbacks', () => {
     dockableForm,
     /destructor TRadIACustomDockableForm\.Destroy;[\s\S]*?DetachNativeForm;/u
   );
-  assert.match(dockableForm, /OnShow := FPreviousOnShow;/u);
-  assert.match(dockableForm, /OnClose := FPreviousOnClose;/u);
   assert.match(dockableForm, /RemoveFreeNotification\(FObserver\)/u);
   assert.match(
     registration,

--- a/docs/guides/mcp_integration_guide.en.md
+++ b/docs/guides/mcp_integration_guide.en.md
@@ -195,7 +195,7 @@ For reproducible automation, prefer `mcp.<pid>.json`.
 1. Open Delphi and a project.
 2. Confirm that `mcp.<pid>.json` exists.
 3. Start or reload the MCP server in the client.
-4. Verify that `initialize` reports RadIA `2.17.1`.
+4. Verify that `initialize` reports RadIA `2.17.2`.
 5. Call `tools/list`.
 6. Call `GetIDEState` and `GetActiveProject`.
 7. Test mutable consent only in a disposable project.

--- a/docs/guides/mcp_integration_guide.md
+++ b/docs/guides/mcp_integration_guide.md
@@ -215,7 +215,7 @@ Para automação reproduzível, prefira sempre `mcp.<pid>.json`.
 1. Abra o Delphi e um projeto.
 2. Confirme que `mcp.<pid>.json` foi criado.
 3. Inicie ou recarregue o servidor no cliente MCP.
-4. Verifique que `initialize` retorna RadIA `2.17.1`.
+4. Verifique que `initialize` retorna RadIA `2.17.2`.
 5. Execute `tools/list`.
 6. Chame `GetIDEState` e `GetActiveProject`.
 7. Para testar consentimento, use uma tool mutável somente em um projeto descartável.

--- a/docs/guides/user_manual.en.md
+++ b/docs/guides/user_manual.en.md
@@ -1,4 +1,4 @@
-# Complete RadIA 2.17.1 user manual
+# Complete RadIA 2.17.2 user manual
 
 > Use `/help` to compare Chat, Agent, CLI, and MCP. When a plan awaits approval, select
 > **Approve plan** or type `/agent resume`.
@@ -36,7 +36,7 @@ layouts such as `Startup Layout` and `Debug Layout`. If the panel is closed befo
 remains closed in the next session; use `Tools > RadIA > Chat` to open it again.
 
 The chat panel caption and primary RadIA windows show the loaded version, for example
-`Rad IA Chat v2.17.1`, so support can confirm the installed build quickly.
+`Rad IA Chat v2.17.2`, so support can confirm the installed build quickly.
 
 Supported credentials are protected locally with Windows DPAPI. Ollama and LM Studio can run
 locally. See the [installation guide](../getting-started/install_config.en.md).

--- a/docs/guides/user_manual.en.md
+++ b/docs/guides/user_manual.en.md
@@ -30,9 +30,10 @@ After installing the package for the intended IDE architecture, open Delphi and 
 panel. Configure a provider under `Tools > Options > Rad IA`, select a model, create a session, and
 send a prompt with `Ctrl + Enter`.
 
-Panel visibility, docked or floating mode, and dimensions follow the IDE desktop and are restored
-the next time Delphi opens. If the panel is closed before exiting, it remains closed in the next
-session; use `Tools > RadIA > Chat` to open it again.
+Docked or floating mode follows the native Delphi desktop. RadIA also records the actual visibility
+and last floating geometry to preserve the user's choice when the IDE switches between named
+layouts such as `Startup Layout` and `Debug Layout`. If the panel is closed before exiting, it
+remains closed in the next session; use `Tools > RadIA > Chat` to open it again.
 
 The chat panel caption and primary RadIA windows show the loaded version, for example
 `Rad IA Chat v2.17.1`, so support can confirm the installed build quickly.

--- a/docs/guides/user_manual.md
+++ b/docs/guides/user_manual.md
@@ -39,9 +39,10 @@ Depois de instalar o pacote correspondente à IDE, abra o Delphi. O RadIA é car
 da IDE e disponibiliza seu painel acoplável. Posicione o painel como uma aba lateral ou janela
 flutuante.
 
-A visibilidade, o modo acoplado ou flutuante e as dimensões do painel acompanham o desktop da IDE e
-são restaurados na próxima abertura do Delphi. Se o painel for fechado antes de sair, ele permanece
-fechado na sessão seguinte; use `Tools > RadIA > Chat` para abri-lo novamente.
+O modo acoplado ou flutuante acompanha o desktop nativo do Delphi. O RadIA também registra a
+visibilidade real e a última geometria flutuante para preservar a escolha do usuário quando a IDE
+troca entre layouts nomeados, como `Startup Layout` e `Debug Layout`. Se o painel for fechado antes
+de sair, ele permanece fechado na sessão seguinte; use `Tools > RadIA > Chat` para abri-lo novamente.
 
 O caption do painel de chat e das janelas principais do RadIA mostra a versão carregada, por exemplo
 `Rad IA Chat v2.17.1`, para facilitar suporte e conferência de instalação.

--- a/docs/guides/user_manual.md
+++ b/docs/guides/user_manual.md
@@ -1,4 +1,4 @@
-# Manual completo do RadIA 2.17.1
+# Manual completo do RadIA 2.17.2
 
 > Para comparar Chat, Agent, CLI e MCP, use `/help`. Quando um plano aguardar aprovação, clique em
 > **Approve plan** ou digite `/agent resume`.
@@ -45,7 +45,7 @@ troca entre layouts nomeados, como `Startup Layout` e `Debug Layout`. Se o paine
 de sair, ele permanece fechado na sessão seguinte; use `Tools > RadIA > Chat` para abri-lo novamente.
 
 O caption do painel de chat e das janelas principais do RadIA mostra a versão carregada, por exemplo
-`Rad IA Chat v2.17.1`, para facilitar suporte e conferência de instalação.
+`Rad IA Chat v2.17.2`, para facilitar suporte e conferência de instalação.
 
 Se o painel ou package não aparecer:
 

--- a/docs/reference/cli_capability_matrix.en.md
+++ b/docs/reference/cli_capability_matrix.en.md
@@ -15,7 +15,7 @@
 
 ## Current matrix
 
-| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.1 use |
+| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.2 use |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Yes, JSONL | Structured event | `exec resume <id>` | Yes | Yes | Not declared | New execution per message |
 | Claude Code | Yes, stream JSON | Structured event | `--resume <id>` | Yes | Yes | Not declared | New execution per message |

--- a/docs/reference/cli_capability_matrix.md
+++ b/docs/reference/cli_capability_matrix.md
@@ -15,7 +15,7 @@
 
 ## Matriz atual
 
-| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.1 |
+| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.2 |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Sim, JSONL | Evento estruturado | `exec resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |
 | Claude Code | Sim, stream JSON | Evento estruturado | `--resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |

--- a/docs/reference/features.en.md
+++ b/docs/reference/features.en.md
@@ -36,7 +36,7 @@ initialization/finalization, and imports outside the project, and applies throug
 | **Goal-oriented Entry** | Chat UX | Welcome screen that starts with understanding, fixing, creating, or debugging, keeps the complete platform visible, and prepares requests without sending. | ✅ Completed |
 | **IDE Theme Integration** | Chat UX | Dark/Light adaptation to the Delphi theme, including Mountain Mist as light, scrollbar polish, and consistent code blocks. | ✅ Completed |
 | **Keyboard Shortcuts** | Chat UX | Shortcut `Ctrl + Enter` to send prompts and simple `Enter` for line breaks. | ✅ Completed |
-| **Layout Persistence** | Chat UX | Automatic saving and restoration of floating window size/position and visibility at startup. | ✅ Completed |
+| **Layout Persistence** | Chat UX | The native desktop restores docking; actual visibility and floating geometry preserve the user's choice across IDE layouts. | ✅ Completed |
 | **Streaming Responses** | Chat UX | Real-time incremental token rendering (SSE) for OpenAI, Gemini, Claude, and Ollama. | ✅ Completed |
 | **Multiple Chat Sessions** | Chat UX | Create, rename, delete, and isolate conversations in a collapsible sidebar, with actions locked during active requests. | ✅ Completed |
 | **Persistent Chat History** | Chat UX | Automatic local JSON storage and on-demand reload of previous chat sessions. | ✅ Completed |

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -36,7 +36,7 @@ initialization/finalization e imports fora do projeto, e usa os patches reversí
 | **Entrada Orientada a Objetivos** | Chat UX | Tela inicial que começa por entender, corrigir, criar ou depurar, mantém a plataforma completa visível e prepara o pedido sem envio automático. | ✅ Concluído |
 | **Tema Integrado à IDE** | Chat UX | Adaptação Dark/Light ao tema do Delphi, incluindo Mountain Mist como light, scrollbar e blocos de código consistentes. | ✅ Concluído |
 | **Atalhos de Teclado** | Chat UX | Atalho `Ctrl + Enter` para enviar prompts e `Enter` para quebra de linha. | ✅ Concluído |
-| **Persistência de Layout** | Chat UX | Salvamento e restauração automática de tamanho/posição flutuante e visibilidade no startup. | ✅ Concluído |
+| **Persistência de Layout** | Chat UX | O desktop nativo restaura o dock; visibilidade real e geometria flutuante preservam a escolha do usuário entre layouts da IDE. | ✅ Concluído |
 | **Streaming de Respostas** | Chat UX | Respostas incrementais token a token (SSE) nos provedores OpenAI, Gemini, Claude e Ollama. | ✅ Concluído |
 | **Múltiplas Sessões de Chat** | Chat UX | Criação, renomeação, exclusão e isolamento de conversas em barra lateral retrátil (bloqueadas durante requisições ativas). | ✅ Concluído |
 | **Histórico de Chat Persistente** | Chat UX | Salvamento automático em JSON e restauração sob demanda das sessões anteriores de chat. | ✅ Concluído |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radia-plugin",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Rad IA - AI Assistant for Delphi IDE",
   "main": "eslint.config.js",
   "scripts": {

--- a/scripts/Test-RadIA.IDESmoke.ps1
+++ b/scripts/Test-RadIA.IDESmoke.ps1
@@ -11,6 +11,7 @@ param(
     [switch]$IDE64,
     [switch]$SkipPackageHashCheck,
     [switch]$ExerciseDocking,
+    [switch]$ExpectDockHidden,
     [switch]$ExerciseWebViewLifecycle,
     [switch]$ExerciseTerminal,
     [switch]$ExerciseInlineCompletion,
@@ -69,6 +70,9 @@ if ($WebViewLifecycleEvidencePath -and -not $ExerciseWebViewLifecycle) {
 }
 if ($ExerciseWebViewLifecycle -and -not $ExerciseDocking) {
     throw "WebView lifecycle validation requires -ExerciseDocking."
+}
+if ($ExerciseDocking -and $ExpectDockHidden) {
+    throw "Docking exercise and hidden-dock validation are mutually exclusive."
 }
 if ($AgentRuntimeEvidencePath -and -not $ExerciseAgentRuntime) {
     throw (
@@ -359,7 +363,7 @@ function Invoke-RadIAPackageLifecycle {
 
 $ErrorActionPreference = "Stop"
 
-if ($ExerciseDocking) {
+if ($ExerciseDocking -or $ExpectDockHidden) {
     if ($Cycles -lt 2) {
         throw "Docking validation requires at least two IDE cycles."
     }
@@ -3346,7 +3350,7 @@ function Invoke-RadIAFirstValueDiagnostic {
 }
 
 function Restore-RadIADockingVisibility {
-    if (-not $script:ExerciseDocking) {
+    if (-not $script:ExerciseDocking -and -not $script:ExpectDockHidden) {
         return
     }
     if ($script:DockingHadWindowVisible) {
@@ -3534,7 +3538,7 @@ trap {
     exit 1
 }
 
-if ($ExerciseDocking) {
+if ($ExerciseDocking -or $ExpectDockHidden) {
     $script:DockingRegistryPath = (
         "HKCU:\Software\Embarcadero\BDS\" +
         "$DelphiVersion\RadIA"
@@ -3561,7 +3565,7 @@ if ($ExerciseDocking) {
         -LiteralPath $script:DockingRegistryPath `
         -Name "WindowVisible" `
         -PropertyType DWord `
-        -Value 1 `
+        -Value $(if ($ExpectDockHidden) { 0 } else { 1 }) `
         -Force |
         Out-Null
 }
@@ -4112,6 +4116,13 @@ for ($cycle = 1; $cycle -le $Cycles; $cycle++) {
                         "after restarting Delphi."
                     )
                 }
+            }
+        }
+        if ($ExpectDockHidden) {
+            Start-Sleep -Seconds 3
+            $currentProcess = Get-Process -Id $process.Id -ErrorAction Stop
+            if (Get-RadIADockInfo -Process $currentProcess) {
+                throw "The RadIA chat opened despite the persisted hidden state."
             }
         }
 
@@ -5089,6 +5100,10 @@ if ($ExerciseDocking) {
         "Native TOTADockForm visibility and desktop-state " +
         "restoration passed."
     )
+    Restore-RadIADockingVisibility
+}
+if ($ExpectDockHidden) {
+    Write-Host "Native RadIA chat remained hidden across IDE startup."
     Restore-RadIADockingVisibility
 }
 if ($ExerciseInlineCompletion) {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # SonarQube Project Configuration
 sonar.projectKey=radia
 sonar.projectName=radia
-sonar.projectVersion=2.17.1
+sonar.projectVersion=2.17.2
 
 # Path to the source directories
 sonar.sources=Source


### PR DESCRIPTION
## O que mudou

- corrige a persistência de visibilidade, tamanho e posição flutuante do chat RadIA;
- registra os docks durante o `Register` do package para participação correta no desktop da IDE;
- observa o estado real do host OTA e persiste alterações antes da remoção do formulário;
- adiciona regressão estática e smoke real para impedir abertura automática após o painel ser fechado;
- prepara os metadados e a documentação permanente para o RadIA 2.17.2.

## Causa raiz

O host OTA não encaminhava de forma confiável os eventos de fechamento e redimensionamento usados pela persistência anterior. O Registro mantinha `WindowVisible=1` e a geometria padrão, mesmo quando o desktop do Delphi registrava a janela fechada.

## Validação

- gate completo `Test-RadIA.ReleaseUsage.ps1` aprovado;
- Delphi 12 e 13: 1.409 testes por versão, zero falhas e leaks;
- E2E real de redimensionar, fechar, reiniciar e permanecer fechado em ambas as IDEs;
- 191 testes web e 45 testes documentais;
- ESLint aprovado;
- SonarQube Quality Gate OK: 84,6% de cobertura global, 1,6% de duplicação e zero issues.
