### PR TITLE
fix: Stabilize project creation agent flow

### DIFF
--- a/RadIA.dproj
+++ b/RadIA.dproj
@@ -65,7 +65,7 @@
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.2.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.2.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.3.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.3.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     </PropertyGroup>
@@ -73,14 +73,14 @@
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.2.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.2.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.3.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.3.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64x)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.2.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.2.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.3.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.3.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <BCC_EnableBatchCompilation>true</BCC_EnableBatchCompilation>
     </PropertyGroup>

--- a/RadIA.rc
+++ b/RadIA.rc
@@ -1,6 +1,6 @@
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,17,2,0
-PRODUCTVERSION 2,17,2,0
+FILEVERSION 2,17,3,0
+PRODUCTVERSION 2,17,3,0
 FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -17,12 +17,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Rad IA Open Source Project\0"
             VALUE "FileDescription", "Rad IA - AI Assistant for Delphi IDE\0"
-            VALUE "FileVersion", "2.17.2.0\0"
+            VALUE "FileVersion", "2.17.3.0\0"
             VALUE "InternalName", "RadIA\0"
             VALUE "LegalCopyright", "Copyright (c) 2026\0"
             VALUE "OriginalFilename", "RadIA.bpl\0"
             VALUE "ProductName", "Rad IA\0"
-            VALUE "ProductVersion", "2.17.2.0\0"
+            VALUE "ProductVersion", "2.17.3.0\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/Source/Core/RadIA.Core.IDENavigationTools.pas
+++ b/Source/Core/RadIA.Core.IDENavigationTools.pas
@@ -424,21 +424,21 @@ begin
         'NavigateToFile',
         'Opens a source file owned by an open project and selects a position.',
         CNavigateFileInputSchema,
-        trReversibleWrite
+        trReadOnly
       );
     intkNavigateToSymbol:
       Result := BuildDescriptor(
         'NavigateToSymbol',
         'Moves the active editor to a declared symbol.',
         CSymbolInputSchema,
-        trReversibleWrite
+        trReadOnly
       );
     intkNavigateToDevelopmentSurface:
       Result := BuildDescriptor(
         'NavigateToDevelopmentSurface',
         'Activates Code or Design from an explicit surface or development intent.',
         CDevelopmentSurfaceInputSchema,
-        trReversibleWrite
+        trReadOnly
       );
     intkListIDEActions:
       Result := BuildDescriptor(

--- a/Source/Core/RadIA.Core.Journeys.pas
+++ b/Source/Core/RadIA.Core.Journeys.pas
@@ -474,6 +474,11 @@ begin
       'profile only after the user explicitly selects or requests those additions. With no active project, ' +
       'use the user-approved destination parent as authorizedRoot. Use OpenCreatedProject, ' +
       'ValidateCreatedProject, and IDE execution tools instead of invoking MSBuild from a CLI. ' +
+      'Do not call NavigateToFile, NavigateToSymbol, or GetKnowledgeDocument before ' +
+      'CreateProjectFromTemplate and OpenCreatedProject succeed. After opening the project, call ' +
+      'GetKnowledgeStatus and only request an indexed document when the status confirms that the ' +
+      'project index is ready. Avoid repeating workspace inspection after the destination, project ' +
+      'type, platform, and active IDE state are known. ' +
       'For executable projects, start the application after a successful build, confirm its main ' +
       'window, exercise the primary user scenario, and record the observed result. When the ' +
       'reviewed preview declares a companionTestExecutable, run that executable through ' +

--- a/Source/Core/RadIA.Core.Version.pas
+++ b/Source/Core/RadIA.Core.Version.pas
@@ -3,7 +3,7 @@ unit RadIA.Core.Version;
 interface
 
 const
-  CRadIAVersion = '2.17.2';
+  CRadIAVersion = '2.17.3';
 
 function RadIAVersionedCaption(const ACaption: string): string;
 

--- a/Source/UI/RadIA.UI.ChatPresenter.pas
+++ b/Source/UI/RadIA.UI.ChatPresenter.pas
@@ -247,6 +247,7 @@ type
       const AProvider: string;
       const AModel: string;
       const ATokenLimit: Integer;
+      const AMaxSteps: Integer;
       out AProviderSettings: TRadIAAgentProviderSettings;
       out ALimits: TRadIAAgentLimits
     );
@@ -4363,6 +4364,7 @@ var
   LEffectiveSettings: TRadIAResolvedExecutionSettings;
   LGuard: IRadIALifecycleGuard;
   LAgentTokenLimit: Integer;
+  LAgentMaxSteps: Integer;
   LLimits: TRadIAAgentLimits;
   LProviderSettings: TRadIAAgentProviderSettings;
   LProject: TRadIAProjectSnapshot;
@@ -4406,10 +4408,16 @@ begin
     LProjectId := LProject.FileName;
   end;
   LAgentTokenLimit := ResolveScopedAgentTokenLimit(LEffectiveSettings);
+  LAgentMaxSteps := 20;
+  if AObjective.Contains(
+    'Create a Delphi project from the user requirements.'
+  ) then
+    LAgentMaxSteps := 40;
   ResolveAgentRuntimeSettings(
     LActiveProvider,
     LActiveModel,
     LAgentTokenLimit,
+    LAgentMaxSteps,
     LProviderSettings,
     LLimits
   );
@@ -4485,6 +4493,7 @@ procedure TRadIAChatPresenter.ResolveAgentRuntimeSettings(
   const AProvider: string;
   const AModel: string;
   const ATokenLimit: Integer;
+  const AMaxSteps: Integer;
   out AProviderSettings: TRadIAAgentProviderSettings;
   out ALimits: TRadIAAgentLimits
 );
@@ -4511,7 +4520,7 @@ begin
         LPricing
       );
       ALimits := TRadIAAgentLimits.Create(
-        20,
+        AMaxSteps,
         3,
         15 * 60 * 1000,
         ATokenLimit,
@@ -4524,7 +4533,7 @@ begin
       BuildAgentToolCatalogJson
     );
     ALimits := TRadIAAgentLimits.Create(
-      20,
+      AMaxSteps,
       3,
       15 * 60 * 1000,
       ATokenLimit,

--- a/Tests/Source/RadIA.Tests.IDENavigation.pas
+++ b/Tests/Source/RadIA.Tests.IDENavigation.pas
@@ -354,11 +354,13 @@ begin
   Assert.IsTrue(FRegistry.TryResolve('ListProjectGroupProjects', LTool));
   Assert.AreEqual(trReadOnly, LTool.Descriptor.Risk);
   Assert.IsTrue(FRegistry.TryResolve('NavigateToFile', LTool));
-  Assert.AreEqual(trReversibleWrite, LTool.Descriptor.Risk);
+  Assert.AreEqual(trReadOnly, LTool.Descriptor.Risk);
+  Assert.IsTrue(FRegistry.TryResolve('NavigateToSymbol', LTool));
+  Assert.AreEqual(trReadOnly, LTool.Descriptor.Risk);
   Assert.IsTrue(
     FRegistry.TryResolve('NavigateToDevelopmentSurface', LTool)
   );
-  Assert.AreEqual(trReversibleWrite, LTool.Descriptor.Risk);
+  Assert.AreEqual(trReadOnly, LTool.Descriptor.Risk);
   Assert.IsTrue(FRegistry.TryResolve('ExecuteIDEAction', LTool));
   Assert.AreEqual(trExecution, LTool.Descriptor.Risk);
 end;

--- a/Tests/Source/RadIA.Tests.Journeys.pas
+++ b/Tests/Source/RadIA.Tests.Journeys.pas
@@ -81,6 +81,13 @@ var
   LDefinition: TRadIAJourneyDefinition;
 begin
   Assert.IsTrue(
+    TRadIAJourneyCatalog.Find('/journey create', LDefinition)
+  );
+  Assert.Contains(LDefinition.Objective, 'CreateProjectFromTemplate');
+  Assert.Contains(LDefinition.Objective, 'OpenCreatedProject succeed');
+  Assert.Contains(LDefinition.Objective, 'GetKnowledgeStatus');
+  Assert.Contains(LDefinition.Objective, 'project index is ready');
+  Assert.IsTrue(
     TRadIAJourneyCatalog.Find('/journey fix-build', LDefinition)
   );
   Assert.Contains(LDefinition.Objective, 'Present a minimal repair plan');

--- a/Tests/Web/RadIA.DebuggerNotifierSafety.test.js
+++ b/Tests/Web/RadIA.DebuggerNotifierSafety.test.js
@@ -113,7 +113,7 @@ test('IDE smoke requests a native editor repaint before visual acceptance', () =
   assert.match(smoke, /\$response\.result\.isError/u);
   assert.match(
     smoke,
-    /Invoke-RadIASmokeToolWithConsent[\s\S]*?-Name "NavigateToFile"/u
+    /Invoke-RadIASmokeTool `[\s\S]*?-Name "NavigateToFile"/u
   );
   assert.match(
     smoke,

--- a/Tests/Web/RadIA.ProjectCreationAgentFlow.test.js
+++ b/Tests/Web/RadIA.ProjectCreationAgentFlow.test.js
@@ -1,0 +1,66 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const navigationTools = fs.readFileSync(
+  path.join('Source', 'Core', 'RadIA.Core.IDENavigationTools.pas'),
+  'utf8'
+);
+const journeys = fs.readFileSync(
+  path.join('Source', 'Core', 'RadIA.Core.Journeys.pas'),
+  'utf8'
+);
+const presenter = fs.readFileSync(
+  path.join('Source', 'UI', 'RadIA.UI.ChatPresenter.pas'),
+  'utf8'
+);
+const e2e = fs.readFileSync(
+  path.join('scripts', 'Test-RadIA.KnowledgeNotifierSmoke.ps1'),
+  'utf8'
+);
+
+test('IDE navigation does not require consent for read-only editor movement', () => {
+  for (const tool of [
+    'NavigateToFile',
+    'NavigateToSymbol',
+    'NavigateToDevelopmentSurface'
+  ]) {
+    assert.match(
+      navigationTools,
+      new RegExp(`${tool}[\\s\\S]*?trReadOnly`, 'u')
+    );
+  }
+});
+
+test('project creation receives a journey-specific step budget', () => {
+  assert.match(
+    presenter,
+    /AObjective\.Contains\([\s\S]*?Create a Delphi project from the user requirements\.[\s\S]*?LAgentMaxSteps := 40/u
+  );
+  assert.match(presenter, /LAgentMaxSteps := 20/u);
+});
+
+test('project creation contract orders creation, opening, indexing and reading', () => {
+  assert.match(
+    journeys,
+    /Do not call NavigateToFile[\s\S]*?CreateProjectFromTemplate and OpenCreatedProject succeed/u
+  );
+  assert.match(
+    journeys,
+    /GetKnowledgeStatus[\s\S]*?project index is ready/u
+  );
+});
+
+test('real IDE E2E navigates without consent and waits for knowledge readiness', () => {
+  assert.match(
+    e2e,
+    /OpenCreatedProject[\s\S]*?Invoke-RadIATool `[\s\S]*?NavigateToFile/u
+  );
+  assert.doesNotMatch(e2e, /immediateNavigation = Invoke-RadIAToolWithConsent/u);
+  assert.match(
+    e2e,
+    /NavigateToFile[\s\S]*?GetKnowledgeStatus[\s\S]*?fileCount[\s\S]*?GetKnowledgeDocument/u
+  );
+  assert.match(e2e, /unexpectedly waited for consent/u);
+});

--- a/Tests/Web/RadIA.ProjectOpeningSynchronization.test.js
+++ b/Tests/Web/RadIA.ProjectOpeningSynchronization.test.js
@@ -37,8 +37,17 @@ test('project readiness compares the registered project path', () => {
 test('IDE integration navigates immediately after opening a generated project', () => {
   assert.match(
     integrationSmokeSource,
-    /OpenCreatedProject[\s\S]*?NavigateToFile[\s\S]*?generatedFormSourcePath/u
+    /OpenCreatedProject[\s\S]*?Invoke-RadIATool `[\s\S]*?NavigateToFile[\s\S]*?generatedFormSourcePath/u
   );
+  assert.doesNotMatch(
+    integrationSmokeSource,
+    /immediateNavigation = Invoke-RadIAToolWithConsent/u
+  );
+  assert.match(
+    integrationSmokeSource,
+    /NavigateToFile[\s\S]*?GetKnowledgeStatus[\s\S]*?fileCount[\s\S]*?GetKnowledgeDocument/u
+  );
+  assert.match(integrationSmokeSource, /unexpectedly waited for consent/u);
   assert.match(integrationGateSource, /SkipTemplateBuild/u);
   assert.match(integrationGateSource, /SkipBuildAndTests/u);
 });

--- a/docs/guides/mcp_integration_guide.en.md
+++ b/docs/guides/mcp_integration_guide.en.md
@@ -195,7 +195,7 @@ For reproducible automation, prefer `mcp.<pid>.json`.
 1. Open Delphi and a project.
 2. Confirm that `mcp.<pid>.json` exists.
 3. Start or reload the MCP server in the client.
-4. Verify that `initialize` reports RadIA `2.17.2`.
+4. Verify that `initialize` reports RadIA `2.17.3`.
 5. Call `tools/list`.
 6. Call `GetIDEState` and `GetActiveProject`.
 7. Test mutable consent only in a disposable project.

--- a/docs/guides/mcp_integration_guide.md
+++ b/docs/guides/mcp_integration_guide.md
@@ -215,7 +215,7 @@ Para automação reproduzível, prefira sempre `mcp.<pid>.json`.
 1. Abra o Delphi e um projeto.
 2. Confirme que `mcp.<pid>.json` foi criado.
 3. Inicie ou recarregue o servidor no cliente MCP.
-4. Verifique que `initialize` retorna RadIA `2.17.2`.
+4. Verifique que `initialize` retorna RadIA `2.17.3`.
 5. Execute `tools/list`.
 6. Chame `GetIDEState` e `GetActiveProject`.
 7. Para testar consentimento, use uma tool mutável somente em um projeto descartável.

--- a/docs/guides/user_guide_project_knowledge.en.md
+++ b/docs/guides/user_guide_project_knowledge.en.md
@@ -36,7 +36,9 @@ and document reads enforce result and payload limits.
 
 Search results and document chunks show an **Open source** action in chat. It uses `NavigateToFile`
 to open the file at the first line of the excerpt. Navigation is read-only and remains subject to
-the active workspace boundary and the normal tool policy.
+the active workspace boundary and the normal tool policy, without a consent prompt. For newly created
+projects, RadIA waits for `GetKnowledgeStatus` to confirm that the index is ready before requesting a
+document body.
 
 The tools also expose local metrics without telemetry: indexing and search report `durationMs`,
 each result retains its relevance scores, and `GetKnowledgeStatus` reports

--- a/docs/guides/user_guide_project_knowledge.md
+++ b/docs/guides/user_guide_project_knowledge.md
@@ -39,7 +39,9 @@ excessivos.
 
 Os resultados de busca e os chunks de um documento exibem a ação **Open source** no chat. Ela usa
 `NavigateToFile` para abrir o arquivo diretamente na linha inicial do trecho. A navegação é somente
-leitura e continua sujeita ao limite do workspace ativo e à política normal de ferramentas.
+leitura, não solicita consentimento e continua sujeita ao limite do workspace ativo e à política normal
+de ferramentas. Em projetos recém-criados, o RadIA aguarda `GetKnowledgeStatus` confirmar que o índice
+está pronto antes de solicitar o conteúdo de um documento.
 
 As ferramentas também expõem métricas locais, sem telemetria: a indexação e a busca informam
 `durationMs`, cada resultado mantém seus scores de relevância e `GetKnowledgeStatus` informa

--- a/docs/guides/user_manual.en.md
+++ b/docs/guides/user_manual.en.md
@@ -1,4 +1,4 @@
-# Complete RadIA 2.17.2 user manual
+# Complete RadIA 2.17.3 user manual
 
 > Use `/help` to compare Chat, Agent, CLI, and MCP. When a plan awaits approval, select
 > **Approve plan** or type `/agent resume`.
@@ -36,7 +36,7 @@ layouts such as `Startup Layout` and `Debug Layout`. If the panel is closed befo
 remains closed in the next session; use `Tools > RadIA > Chat` to open it again.
 
 The chat panel caption and primary RadIA windows show the loaded version, for example
-`Rad IA Chat v2.17.2`, so support can confirm the installed build quickly.
+`Rad IA Chat v2.17.3`, so support can confirm the installed build quickly.
 
 Supported credentials are protected locally with Windows DPAPI. Ollama and LM Studio can run
 locally. See the [installation guide](../getting-started/install_config.en.md).

--- a/docs/guides/user_manual.md
+++ b/docs/guides/user_manual.md
@@ -1,4 +1,4 @@
-# Manual completo do RadIA 2.17.2
+# Manual completo do RadIA 2.17.3
 
 > Para comparar Chat, Agent, CLI e MCP, use `/help`. Quando um plano aguardar aprovação, clique em
 > **Approve plan** ou digite `/agent resume`.
@@ -45,7 +45,7 @@ troca entre layouts nomeados, como `Startup Layout` e `Debug Layout`. Se o paine
 de sair, ele permanece fechado na sessão seguinte; use `Tools > RadIA > Chat` para abri-lo novamente.
 
 O caption do painel de chat e das janelas principais do RadIA mostra a versão carregada, por exemplo
-`Rad IA Chat v2.17.2`, para facilitar suporte e conferência de instalação.
+`Rad IA Chat v2.17.3`, para facilitar suporte e conferência de instalação.
 
 Se o painel ou package não aparecer:
 

--- a/docs/reference/cli_capability_matrix.en.md
+++ b/docs/reference/cli_capability_matrix.en.md
@@ -15,7 +15,7 @@
 
 ## Current matrix
 
-| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.2 use |
+| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.3 use |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Yes, JSONL | Structured event | `exec resume <id>` | Yes | Yes | Not declared | New execution per message |
 | Claude Code | Yes, stream JSON | Structured event | `--resume <id>` | Yes | Yes | Not declared | New execution per message |

--- a/docs/reference/cli_capability_matrix.md
+++ b/docs/reference/cli_capability_matrix.md
@@ -15,7 +15,7 @@
 
 ## Matriz atual
 
-| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.2 |
+| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.3 |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Sim, JSONL | Evento estruturado | `exec resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |
 | Claude Code | Sim, stream JSON | Evento estruturado | `--resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radia-plugin",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "Rad IA - AI Assistant for Delphi IDE",
   "main": "eslint.config.js",
   "scripts": {

--- a/scripts/Test-RadIA.IDESmoke.ps1
+++ b/scripts/Test-RadIA.IDESmoke.ps1
@@ -1984,10 +1984,9 @@ function Invoke-RadIAFireDACReadOnlyScenario {
             if ($sqlLine -lt 1 -or $sqlColumn -lt 1) {
                 throw "The SQL fixture text was not found."
             }
-            $navigation = Invoke-RadIASmokeToolWithConsent `
+            $navigation = Invoke-RadIASmokeTool `
                 -BridgePath $BridgePath `
                 -InstanceFile $InstanceFile `
-                -IDEProcess $IDEProcess `
                 -Name "NavigateToFile" `
                 -Arguments @{
                     fileName = $targetFile

--- a/scripts/Test-RadIA.KnowledgeNotifierSmoke.ps1
+++ b/scripts/Test-RadIA.KnowledgeNotifierSmoke.ps1
@@ -417,7 +417,8 @@ function Invoke-RadIATool {
         [string]$InstanceFile,
         [Parameter(Mandatory = $true)]
         [string]$Name,
-        [hashtable]$Arguments = @{}
+        [hashtable]$Arguments = @{},
+        [switch]$ExpectError
     )
 
     $initialize = @{
@@ -480,8 +481,14 @@ function Invoke-RadIATool {
         throw "Tool $Name failed: $($response.error.message)"
     }
     if ($response.result.isError) {
+        if ($ExpectError) {
+            return $response.result
+        }
         $message = $response.result.content[0].text
         throw "Tool $Name returned an error: $message"
+    }
+    if ($ExpectError) {
+        throw "Tool $Name unexpectedly succeeded."
     }
     return $response.result.structuredContent
 }
@@ -1348,10 +1355,10 @@ try {
         if (-not $templateOpen.opened) {
             throw "The generated VCL project was not opened."
         }
-        $immediateNavigation = Invoke-RadIAToolWithConsent `
+        $navigationStartedAt = [DateTime]::UtcNow
+        $immediateNavigation = Invoke-RadIATool `
             -BridgePath $bridgePath `
             -InstanceFile $instanceFile `
-            -IDEProcess $process `
             -Name "NavigateToFile" `
             -Arguments @{
                 fileName = $generatedFormSourcePath
@@ -1369,6 +1376,35 @@ try {
                 "Navigation failed immediately after opening the " +
                 "generated project."
             )
+        }
+        if (([DateTime]::UtcNow - $navigationStartedAt).TotalSeconds -ge 15) {
+            throw "Read-only source navigation unexpectedly waited for consent."
+        }
+
+        $knowledgeDeadline = [DateTime]::UtcNow.AddSeconds(30)
+        do {
+            $knowledgeStatus = Invoke-RadIATool `
+                -BridgePath $bridgePath `
+                -InstanceFile $instanceFile `
+                -Name "GetKnowledgeStatus"
+            if ($knowledgeStatus.loaded -and $knowledgeStatus.fileCount -gt 0) {
+                break
+            }
+            Start-Sleep -Milliseconds 250
+        } while ([DateTime]::UtcNow -lt $knowledgeDeadline)
+        if (-not $knowledgeStatus.loaded -or $knowledgeStatus.fileCount -lt 1) {
+            throw "The generated project knowledge index did not become ready."
+        }
+        $generatedDocument = Invoke-RadIATool `
+            -BridgePath $bridgePath `
+            -InstanceFile $instanceFile `
+            -Name "GetKnowledgeDocument" `
+            -Arguments @{
+                fileName = $generatedFormSourcePath
+                maxCharacters = 65536
+            }
+        if ($generatedDocument.chunks.Count -lt 1) {
+            throw "The generated form was absent from the ready knowledge index."
         }
     } else {
         $templateValidation = Invoke-RadIAToolWithConsent `
@@ -1443,10 +1479,9 @@ try {
         $activeForm.name -ne "RadIAMainForm") {
         throw "The generated VCL form did not become active in the Designer."
     }
-    $designNavigation = Invoke-RadIAToolWithConsent `
+    $designNavigation = Invoke-RadIATool `
         -BridgePath $bridgePath `
         -InstanceFile $instanceFile `
-        -IDEProcess $process `
         -Name "NavigateToDevelopmentSurface" `
         -Arguments @{
             fileName = $generatedFormSourcePath
@@ -1456,10 +1491,9 @@ try {
         throw "The edit-layout intent did not activate the Form Designer."
     }
     $developmentSurfaceDesignPassed = $true
-    $codeNavigation = Invoke-RadIAToolWithConsent `
+    $codeNavigation = Invoke-RadIATool `
         -BridgePath $bridgePath `
         -InstanceFile $instanceFile `
-        -IDEProcess $process `
         -Name "NavigateToDevelopmentSurface" `
         -Arguments @{
             fileName = $generatedFormSourcePath
@@ -1469,10 +1503,9 @@ try {
         throw "The implement-event intent did not activate the Code editor."
     }
     $developmentSurfaceCodePassed = $true
-    [void](Invoke-RadIAToolWithConsent `
+    [void](Invoke-RadIATool `
         -BridgePath $bridgePath `
         -InstanceFile $instanceFile `
-        -IDEProcess $process `
         -Name "NavigateToDevelopmentSurface" `
         -Arguments @{
             fileName = $generatedFormSourcePath
@@ -1481,18 +1514,19 @@ try {
         -ExpectError
     )
     $developmentSurfaceErrorPassed = $true
-    [void](Invoke-RadIAToolWithConsent `
+    $surfaceNavigationStartedAt = [DateTime]::UtcNow
+    $surfaceNavigation = Invoke-RadIATool `
         -BridgePath $bridgePath `
         -InstanceFile $instanceFile `
-        -IDEProcess $process `
         -Name "NavigateToDevelopmentSurface" `
         -Arguments @{
             fileName = $generatedFormSourcePath
             intent = "edit-layout"
-        } `
-        -ConsentButtonText "Cancel" `
-        -ExpectError
-    )
+        }
+    if (-not $surfaceNavigation.message -or
+        ([DateTime]::UtcNow - $surfaceNavigationStartedAt).TotalSeconds -ge 15) {
+        throw "Read-only surface navigation unexpectedly waited for consent."
+    }
     $developmentSurfaceCancellationPassed = $true
     $propertyPreview = Invoke-RadIATool `
         -BridgePath $bridgePath `
@@ -2001,10 +2035,9 @@ try {
             -not $executionResults[1].success) {
             throw "The replacement project did not validate."
         }
-        $transitionNavigation = Invoke-RadIAToolWithConsent `
+        $transitionNavigation = Invoke-RadIATool `
             -BridgePath $bridgePath `
             -InstanceFile $instanceFile `
-            -IDEProcess $process `
             -Name "NavigateToFile" `
             -Arguments @{
                 fileName = $transitionProjectSourcePath

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # SonarQube Project Configuration
 sonar.projectKey=radia
 sonar.projectName=radia
-sonar.projectVersion=2.17.2
+sonar.projectVersion=2.17.3
 
 # Path to the source directories
 sonar.sources=Source


### PR DESCRIPTION
## Resumo\n\nCorrige o fluxo de criação de projetos que podia consumir o limite de passos após uma aprovação de navegação expirar e consultar o índice antes de ele ficar pronto.\n\n## Alterações\n\n- navegação de editor classificada como leitura, sem consentimento modal;\n- orçamento de 40 passos apenas para a jornada de criação;\n- sequência obrigatória de criar, abrir, aguardar a indexação e consultar;\n- E2E real contra Delphi 12 e 13;\n- versão preparada como 2.17.3.\n\n## Validação\n\n- DUnitX: 1.401 internos e 8 externos por versão;\n- E2E completo aprovado no Delphi 12 e 13;\n- 195 testes web aprovados;\n- lint e documentação aprovados.