### PR TITLE
release: RadIA 2.17.5

### DIFF
--- a/RadIA.dproj
+++ b/RadIA.dproj
@@ -65,7 +65,7 @@
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.4.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.4.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.5.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.5.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     </PropertyGroup>
@@ -73,14 +73,14 @@
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.4.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.4.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.5.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.5.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64x)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.4.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.4.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.5.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.5.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <BCC_EnableBatchCompilation>true</BCC_EnableBatchCompilation>
     </PropertyGroup>

--- a/RadIA.rc
+++ b/RadIA.rc
@@ -1,6 +1,6 @@
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,17,4,0
-PRODUCTVERSION 2,17,4,0
+FILEVERSION 2,17,5,0
+PRODUCTVERSION 2,17,5,0
 FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -17,12 +17,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Rad IA Open Source Project\0"
             VALUE "FileDescription", "Rad IA - AI Assistant for Delphi IDE\0"
-            VALUE "FileVersion", "2.17.4.0\0"
+            VALUE "FileVersion", "2.17.5.0\0"
             VALUE "InternalName", "RadIA\0"
             VALUE "LegalCopyright", "Copyright (c) 2026\0"
             VALUE "OriginalFilename", "RadIA.bpl\0"
             VALUE "ProductName", "Rad IA\0"
-            VALUE "ProductVersion", "2.17.4.0\0"
+            VALUE "ProductVersion", "2.17.5.0\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/Source/Core/RadIA.Core.AgentProvider.pas
+++ b/Source/Core/RadIA.Core.AgentProvider.pas
@@ -224,10 +224,11 @@ begin
     'You are the RadIA agent planner running inside RAD Studio. ' +
     'Choose exactly one next action for the objective and current state. ' +
     'Use only a tool from the supplied catalog. Never invent a tool. ' +
-    'Before the first tool call, return a concise plan for user approval. ' +
-    'If CURRENT_STATE.plan is empty, the only valid response is: ' +
-    '{"kind":"plan","message":"Approve this plan to continue.",' +
-    '"steps":[{"title":"Inspect","description":"Read current state"}]}. ' +
+    'Before the first tool call, return a concise and objective-specific plan for user approval. ' +
+    'If CURRENT_STATE.plan is empty, return kind plan with a steps array. ' +
+    'The steps must cover the requested outcome, required inspection, implementation, and validation. ' +
+    'Preserve every explicit functional requirement from CURRENT_STATE.objective. ' +
+    'Do not return a generic inspection-only plan for a creation or modification objective. ' +
     'After CURRENT_STATE.planApproved is true, choose the next action. ' +
     'Return one JSON object and no markdown. Valid responses are: ' +
     '{"kind":"tool","tool":"ToolName","arguments":{}}, ' +

--- a/Source/Core/RadIA.Core.AgentRuntime.pas
+++ b/Source/Core/RadIA.Core.AgentRuntime.pas
@@ -2174,6 +2174,7 @@ function TRadIAAgentRuntime.CheckRepeatedCall(
   const ADecision: TRadIAAgentDecision
 ): Boolean;
 var
+  LAllowedRepeatedCalls: Integer;
   LSignature: string;
 begin
   LSignature := BuildCallSignature(ADecision);
@@ -2184,7 +2185,10 @@ begin
     FLastCallSignature := LSignature;
     FRepeatedCallCount := 1;
   end;
-  Result := FRepeatedCallCount <= FLimits.MaxRepeatedCalls;
+  LAllowedRepeatedCalls := FLimits.MaxRepeatedCalls;
+  if SameText(ADecision.ToolName, 'GetToolResultRange') then
+    LAllowedRepeatedCalls := 1;
+  Result := FRepeatedCallCount <= LAllowedRepeatedCalls;
 end;
 
 function TRadIAAgentRuntime.CanContinueLoop: Boolean;

--- a/Source/Core/RadIA.Core.Journeys.pas
+++ b/Source/Core/RadIA.Core.Journeys.pas
@@ -219,6 +219,16 @@ begin
   AppendCreateContextValue(Result, LLowerContext, 'project', LProjectName);
   AppendCreateContextValue(Result, LLowerContext, 'type', LProjectType);
   AppendCreateContextValue(Result, LLowerContext, 'platform', 'Win32');
+  if ContainsAnyText(LLowerContext, ['calculadora', 'calculator']) and
+    ContainsAnyText(
+      LLowerContext,
+      [
+        'historico', 'histórico', 'lista de calculos', 'lista de cálculos',
+        'ultimas operacoes', 'últimas operações', 'operation history',
+        'calculation history'
+      ]
+    ) then
+    Result := Result + ' feature="operationHistory"';
 end;
 
 class function TRadIAJourneyCatalog.TryInferCreateProject(
@@ -471,7 +481,14 @@ begin
       'essential by default. Never add tests or other optional project features based only on a ' +
       'generic request for a project. After the essential project builds, present explicit choices ' +
       'to keep it as-is or add DUnitX and other available features. Apply a complete or custom ' +
-      'profile only after the user explicitly selects or requests those additions. With no active project, ' +
+      'profile only after the user explicitly selects or requests those additions. ' +
+      'When calculator context includes feature="operationHistory", preserve it with ' +
+      'projectSpecification schemaVersion 2 and features.operationHistory enabled and clearAction true. ' +
+      'The preview, plan, completion criteria, generated files, and runtime evidence must all retain every ' +
+      'explicit functional feature from the user context. A successful build alone does not prove a requested ' +
+      'feature. For operation history, exercise two calculations, verify their ordered history entries, clear ' +
+      'the history, and verify that it is empty before completing. ' +
+      'With no active project, ' +
       'use the user-approved destination parent as authorizedRoot. Use OpenCreatedProject, ' +
       'ValidateCreatedProject, and IDE execution tools instead of invoking MSBuild from a CLI. ' +
       'Do not call NavigateToFile, NavigateToSymbol, or GetKnowledgeDocument before ' +

--- a/Source/Core/RadIA.Core.ProjectTemplateTools.pas
+++ b/Source/Core/RadIA.Core.ProjectTemplateTools.pas
@@ -134,12 +134,17 @@ const
     '"authorizedRoot":{"type":"string"},' +
     '"destinationPath":{"type":"string"},' +
     '"projectSpecification":{"type":"object","properties":{' +
-    '"schemaVersion":{"type":"integer","const":1},' +
+    '"schemaVersion":{"type":"integer","enum":[1,2]},' +
     '"kind":{"type":"string","enum":["calculator"]},' +
     '"creationProfile":{"type":"string","enum":[' +
     '"essential","complete","custom"],"default":"essential"},' +
     '"optionalFeatures":{"type":"array","uniqueItems":true,' +
-    '"items":{"type":"string","enum":["dunitx"]}}},' +
+    '"items":{"type":"string","enum":["dunitx"]}},' +
+    '"features":{"type":"object","properties":{' +
+    '"operationHistory":{"type":"object","properties":{' +
+    '"enabled":{"type":"boolean"},"clearAction":{"type":"boolean"}},' +
+    '"required":["enabled"],"additionalProperties":false}},' +
+    '"additionalProperties":false}},' +
     '"required":["schemaVersion","kind"],' +
     '"additionalProperties":false},' +
     '"apiSpecification":{"type":"object","required":[' +

--- a/Source/Core/RadIA.Core.ProjectTemplates.pas
+++ b/Source/Core/RadIA.Core.ProjectTemplates.pas
@@ -124,6 +124,9 @@ type
     function IncludesCalculatorTests(
       const ARequest: TRadIAProjectTemplateRequest
     ): Boolean;
+    function IncludesCalculatorHistory(
+      const ARequest: TRadIAProjectTemplateRequest
+    ): Boolean;
     function IsVclCalculator(
       const ARequest: TRadIAProjectTemplateRequest
     ): Boolean;
@@ -248,6 +251,7 @@ end;
 function TRadIAProjectTemplatePlan.PreviewJson: string;
 var
   LCompanionTestProject: string;
+  LFeatures: TJSONValue;
   LFile: TRadIAProjectTemplateFile;
   LFileJson: TJSONObject;
   LFiles: TJSONArray;
@@ -275,6 +279,7 @@ begin
             LSpecification.GetValue<string>('kind', ''),
             'calculator'
           ) then
+        begin
           LRoot.AddPair(
             'creationProfile',
             LSpecification.GetValue<string>(
@@ -282,6 +287,10 @@ begin
               'essential'
             )
           );
+          LFeatures := LSpecification.GetValue('features');
+          if Assigned(LFeatures) then
+            LRoot.AddPair('features', LFeatures.Clone as TJSONValue);
+        end;
       finally
         LSpecification.Free;
       end;
@@ -705,16 +714,152 @@ begin
   end;
 end;
 
+function TRadIAProjectTemplateEngine.IncludesCalculatorHistory(
+  const ARequest: TRadIAProjectTemplateRequest
+): Boolean;
+var
+  LFeatures: TJSONObject;
+  LHistory: TJSONObject;
+  LJson: TJSONObject;
+begin
+  Result := False;
+  LJson := TJSONObject.ParseJSONValue(
+    ARequest.SpecificationJson
+  ) as TJSONObject;
+  try
+    if not Assigned(LJson) then
+      Exit;
+    LFeatures := LJson.GetValue('features') as TJSONObject;
+    if not Assigned(LFeatures) then
+      Exit;
+    LHistory := LFeatures.GetValue('operationHistory') as TJSONObject;
+    Result := Assigned(LHistory) and
+      LHistory.GetValue<Boolean>('enabled', False);
+  finally
+    LJson.Free;
+  end;
+end;
+
 function TRadIAProjectTemplateEngine.BuildVclCalculatorFiles(
   const ARequest: TRadIAProjectTemplateRequest;
   const ATemplateId: string
 ): TArray<TRadIAProjectTemplateFile>;
 var
   LDfm: string;
+  LEqualsImplementation: string;
+  LHistoryDfm: string;
+  LHistoryPrivate: string;
+  LHistoryPublished: string;
+  LHistoryWidth: Integer;
   LProjectName: string;
   LSource: string;
 begin
   LProjectName := ARequest.ProjectName;
+  LHistoryPublished := '';
+  LHistoryPrivate := '';
+  LHistoryDfm := '';
+  LHistoryWidth := 260;
+  if IncludesCalculatorHistory(ARequest) then
+  begin
+    LHistoryWidth := 520;
+    LHistoryPublished :=
+      '    ClearHistoryButton: TButton;' + sLineBreak +
+      '    HistoryStatus: TEdit;' + sLineBreak +
+      '    OperationHistory: TListBox;' + sLineBreak +
+      '    procedure ClearHistoryClick(Sender: TObject);' + sLineBreak;
+    LHistoryPrivate :=
+      '    procedure AddHistoryEntry(' + sLineBreak +
+      '      const ALeft: Double;' + sLineBreak +
+      '      const AOperator: string;' + sLineBreak +
+      '      const ARight, AResult: Double' + sLineBreak +
+      '    );' + sLineBreak;
+    LEqualsImplementation :=
+      'procedure TRadIAMainForm.AddHistoryEntry(' + sLineBreak +
+      '  const ALeft: Double;' + sLineBreak +
+      '  const AOperator: string;' + sLineBreak +
+      '  const ARight, AResult: Double' + sLineBreak +
+      ');' + sLineBreak +
+      'begin' + sLineBreak +
+      '  HistoryStatus.Text := Format(''%g %s %g = %g'', [' +
+      'ALeft, AOperator, ARight, AResult]);' + sLineBreak +
+      '  OperationHistory.Items.Add(HistoryStatus.Text);' + sLineBreak +
+      'end;' + sLineBreak + sLineBreak +
+      'procedure TRadIAMainForm.ClearHistoryClick(Sender: TObject);' + sLineBreak +
+      'begin' + sLineBreak +
+      '  OperationHistory.Clear;' + sLineBreak +
+      '  HistoryStatus.Clear;' + sLineBreak +
+      'end;' + sLineBreak + sLineBreak +
+      'procedure TRadIAMainForm.EqualsClick(Sender: TObject);' + sLineBreak +
+      'var' + sLineBreak +
+      '  LLeft: Double;' + sLineBreak +
+      '  LOperator: string;' + sLineBreak +
+      '  LRight: Double;' + sLineBreak +
+      'begin' + sLineBreak +
+      '  if FPendingOperator = '''' then' + sLineBreak +
+      '    Exit;' + sLineBreak +
+      '  LLeft := FAccumulator;' + sLineBreak +
+      '  LOperator := FPendingOperator;' + sLineBreak +
+      '  LRight := CurrentValue;' + sLineBreak +
+      '  try' + sLineBreak +
+      '    ApplyPendingOperator;' + sLineBreak +
+      '    Display.Text := FloatToStr(FAccumulator);' + sLineBreak +
+      '    AddHistoryEntry(LLeft, LOperator, LRight, FAccumulator);' + sLineBreak +
+      '    FPendingOperator := '''';' + sLineBreak +
+      '    FNewEntry := True;' + sLineBreak +
+      '  except' + sLineBreak +
+      '    on E: EDivByZero do' + sLineBreak +
+      '    begin' + sLineBreak +
+      '      Display.Text := ''Cannot divide by zero'';' + sLineBreak +
+      '      FPendingOperator := '''';' + sLineBreak +
+      '      FNewEntry := True;' + sLineBreak +
+      '    end;' + sLineBreak +
+      '  end;' + sLineBreak +
+      'end;' + sLineBreak + sLineBreak;
+    LHistoryDfm :=
+      '  object OperationHistory: TListBox' + sLineBreak +
+      '    Left = 276' + sLineBreak +
+      '    Top = 16' + sLineBreak +
+      '    Width = 228' + sLineBreak +
+      '    Height = 225' + sLineBreak +
+      '    ItemHeight = 15' + sLineBreak +
+      '    TabOrder = 18' + sLineBreak +
+      '  end' + sLineBreak +
+      '  object HistoryStatus: TEdit' + sLineBreak +
+      '    Left = 276' + sLineBreak +
+      '    Top = 249' + sLineBreak +
+      '    Width = 228' + sLineBreak +
+      '    Height = 23' + sLineBreak +
+      '    ReadOnly = True' + sLineBreak +
+      '    TabOrder = 19' + sLineBreak +
+      '  end' + sLineBreak +
+      '  object ClearHistoryButton: TButton' + sLineBreak +
+      '    Left = 276' + sLineBreak +
+      '    Top = 281' + sLineBreak +
+      '    Width = 228' + sLineBreak +
+      '    Height = 33' + sLineBreak +
+      '    Caption = ''Clear history''' + sLineBreak +
+      '    TabOrder = 20' + sLineBreak +
+      '    OnClick = ClearHistoryClick' + sLineBreak +
+      '  end' + sLineBreak;
+  end
+  else
+    LEqualsImplementation :=
+      'procedure TRadIAMainForm.EqualsClick(Sender: TObject);' + sLineBreak +
+      'begin' + sLineBreak +
+      '  try' + sLineBreak +
+      '    ApplyPendingOperator;' + sLineBreak +
+      '    Display.Text := FloatToStr(FAccumulator);' + sLineBreak +
+      '    FPendingOperator := '''';' + sLineBreak +
+      '    FNewEntry := True;' + sLineBreak +
+      '  except' + sLineBreak +
+      '    on E: EDivByZero do' + sLineBreak +
+      '    begin' + sLineBreak +
+      '      Display.Text := ''Cannot divide by zero'';' + sLineBreak +
+      '      FPendingOperator := '''';' + sLineBreak +
+      '      FNewEntry := True;' + sLineBreak +
+      '    end;' + sLineBreak +
+      '  end;' + sLineBreak +
+      'end;' + sLineBreak + sLineBreak;
   LSource :=
     'unit MainForm;' + sLineBreak + sLineBreak +
     'interface' + sLineBreak + sLineBreak +
@@ -746,6 +891,7 @@ begin
     '    ThreeButton: TButton;' + sLineBreak +
     '    TwoButton: TButton;' + sLineBreak +
     '    ZeroButton: TButton;' + sLineBreak +
+    LHistoryPublished +
     '    procedure ClearClick(Sender: TObject);' + sLineBreak +
     '    procedure DigitClick(Sender: TObject);' + sLineBreak +
     '    procedure EqualsClick(Sender: TObject);' + sLineBreak +
@@ -754,6 +900,7 @@ begin
     '    FAccumulator: Double;' + sLineBreak +
     '    FNewEntry: Boolean;' + sLineBreak +
     '    FPendingOperator: string;' + sLineBreak +
+    LHistoryPrivate +
     '    function CurrentValue: Double;' + sLineBreak +
     '    procedure ApplyPendingOperator;' + sLineBreak +
     '  end;' + sLineBreak + sLineBreak +
@@ -810,22 +957,7 @@ begin
     '  FPendingOperator := TButton(Sender).Caption;' + sLineBreak +
     '  FNewEntry := True;' + sLineBreak +
     'end;' + sLineBreak + sLineBreak +
-    'procedure TRadIAMainForm.EqualsClick(Sender: TObject);' + sLineBreak +
-    'begin' + sLineBreak +
-    '  try' + sLineBreak +
-    '    ApplyPendingOperator;' + sLineBreak +
-    '    Display.Text := FloatToStr(FAccumulator);' + sLineBreak +
-    '    FPendingOperator := '''';' + sLineBreak +
-    '    FNewEntry := True;' + sLineBreak +
-    '  except' + sLineBreak +
-    '    on E: EDivByZero do' + sLineBreak +
-    '    begin' + sLineBreak +
-    '      Display.Text := ''Cannot divide by zero'';' + sLineBreak +
-    '      FPendingOperator := '''';' + sLineBreak +
-    '      FNewEntry := True;' + sLineBreak +
-    '    end;' + sLineBreak +
-    '  end;' + sLineBreak +
-    'end;' + sLineBreak + sLineBreak +
+    LEqualsImplementation +
     'end.' + sLineBreak;
   LDfm :=
     'object RadIAMainForm: TRadIAMainForm' + sLineBreak +
@@ -833,7 +965,7 @@ begin
     '  Top = 0' + sLineBreak +
     '  Caption = ''' + LProjectName + '''' + sLineBreak +
     '  ClientHeight = 330' + sLineBreak +
-    '  ClientWidth = 260' + sLineBreak +
+    '  ClientWidth = ' + LHistoryWidth.ToString + sLineBreak +
     '  Position = poScreenCenter' + sLineBreak +
     '  object Display: TEdit' + sLineBreak +
     '    Left = 16' + sLineBreak +
@@ -846,6 +978,7 @@ begin
     '    Text = ''0''' + sLineBreak +
     '  end' + sLineBreak +
     BuildCalculatorButtons +
+    LHistoryDfm +
     'end' + sLineBreak;
   Result := [
     TRadIAProjectTemplateFile.Create(

--- a/Source/Core/RadIA.Core.Version.pas
+++ b/Source/Core/RadIA.Core.Version.pas
@@ -3,7 +3,7 @@ unit RadIA.Core.Version;
 interface
 
 const
-  CRadIAVersion = '2.17.4';
+  CRadIAVersion = '2.17.5';
 
 function RadIAVersionedCaption(const ACaption: string): string;
 

--- a/Tests/Source/RadIA.Tests.AgentRuntime.pas
+++ b/Tests/Source/RadIA.Tests.AgentRuntime.pas
@@ -180,6 +180,8 @@ type
     [Test]
     procedure TestStopsRepeatedToolCalls;
     [Test]
+    procedure TestStopsDuplicateArtifactRangeImmediately;
+    [Test]
     procedure TestPauseAndResumeFromCheckpoint;
     [Test]
     procedure TestReplayStepAppendsAuditedPausedResult;
@@ -1438,6 +1440,50 @@ begin
     );
     Assert.AreEqual(asAwaitingApproval, LResult.Status);
     LResult := LRuntime.Resume('repeat-session');
+    Assert.AreEqual(asFailed, LResult.Status);
+    Assert.AreEqual(1, LResult.StepCount);
+    Assert.Contains(LResult.Message, 'repeated too many times');
+  finally
+    LRuntime.Free;
+  end;
+end;
+
+procedure TTestRadIAAgentRuntime.TestStopsDuplicateArtifactRangeImmediately;
+var
+  LExecutor: IRadIAToolExecutor;
+  LProvider: IRadIAAgentDecisionProvider;
+  LStore: IRadIAAgentCheckpointStore;
+  LRuntime: TRadIAAgentRuntime;
+  LResult: TRadIAAgentRunResult;
+begin
+  LExecutor := TRadIAMockAgentToolExecutor.Create(
+    TRadIAToolResult.Succeeded('{"content":"same range"}')
+  );
+  LProvider := TRadIAMockAgentDecisionProvider.Create([
+    TRadIAAgentDecision.Plan(
+      'Review artifact recovery.',
+      '[{"title":"Recover one artifact range"}]'
+    ),
+    TRadIAAgentDecision.CallTool(
+      'GetToolResultRange',
+      '{"artifactId":"artifact-1","offset":0,"length":100}'
+    ),
+    TRadIAAgentDecision.CallTool(
+      'GetToolResultRange',
+      '{"artifactId":"artifact-1","offset":0,"length":100}'
+    )
+  ]);
+  LStore := TRadIAMemoryAgentCheckpointStore.Create;
+  LRuntime := NewRuntime(LExecutor, LProvider, LStore);
+  try
+    LResult := LRuntime.Start(
+      'Recover one artifact range.',
+      'duplicate-artifact-range-session',
+      'project',
+      TRadIAAgentLimits.Default
+    );
+    Assert.AreEqual(asAwaitingApproval, LResult.Status);
+    LResult := LRuntime.Resume('duplicate-artifact-range-session');
     Assert.AreEqual(asFailed, LResult.Status);
     Assert.AreEqual(1, LResult.StepCount);
     Assert.Contains(LResult.Message, 'repeated too many times');

--- a/Tests/Source/RadIA.Tests.Journeys.pas
+++ b/Tests/Source/RadIA.Tests.Journeys.pas
@@ -34,6 +34,8 @@ type
     [Test]
     procedure NaturalCreateContextExtractsDestinationNameAndDefaultPlatform;
     [Test]
+    procedure NaturalCalculatorHistoryPreservesFunctionalFeature;
+    [Test]
     procedure NaturalPromptsNormalizeEverySupportedTemplate;
   end;
 
@@ -351,6 +353,18 @@ begin
   Assert.Contains(LContext, 'platform="Win32"');
   Assert.IsTrue(TRadIAJourneyCatalog.Find('/journey create', LDefinition));
   Assert.IsFalse(LDefinition.NextRequiredInput(LContext, LField, LQuestion));
+end;
+
+procedure TTestRadIAJourneys.
+  NaturalCalculatorHistoryPreservesFunctionalFeature;
+var
+  LContext: string;
+begin
+  LContext := TRadIAJourneyCatalog.NormalizeCreateContext(
+    'crie uma calculadora com histórico de operações em D:\HistoryCalculator'
+  );
+  Assert.Contains(LContext, 'feature="operationHistory"');
+  Assert.Contains(LContext, 'type="VCL"');
 end;
 
 procedure TTestRadIAJourneys.NaturalPromptsNormalizeEverySupportedTemplate;

--- a/Tests/Source/RadIA.Tests.ProjectTemplates.pas
+++ b/Tests/Source/RadIA.Tests.ProjectTemplates.pas
@@ -33,6 +33,8 @@ type
     procedure TestCalculatorEssentialProfileOmitsCompanionTests;
     [Test]
     procedure TestCalculatorCustomProfileCanIncludeDUnitX;
+    [Test]
+    procedure TestCalculatorHistoryFeatureProducesFunctionalHistory;
   end;
 
 implementation
@@ -170,6 +172,7 @@ begin
       for LFile in LPlan.Files do
       begin
         Assert.DoesNotContain(LFile.RelativePath, 'Tests');
+        Assert.DoesNotContain(LFile.Content, 'OperationHistory');
         if SameText(LFile.RelativePath, 'EssentialCalculator.dproj') then
           Assert.DoesNotContain(LFile.Content, 'RadIABuildCompanionTests');
       end;
@@ -178,6 +181,63 @@ begin
         '"creationProfile":"essential"'
       );
       Assert.DoesNotContain(LPlan.PreviewJson, 'companionTestProject');
+    finally
+      LPlan.Free;
+    end;
+  finally
+    LEngine.Free;
+  end;
+end;
+
+procedure TTestRadIAProjectTemplates.
+  TestCalculatorHistoryFeatureProducesFunctionalHistory;
+var
+  LEngine: TRadIAProjectTemplateEngine;
+  LFile: TRadIAProjectTemplateFile;
+  LFoundDfm: Boolean;
+  LFoundSource: Boolean;
+  LPlan: TRadIAProjectTemplatePlan;
+begin
+  LEngine := TRadIAProjectTemplateEngine.Create;
+  try
+    LPlan := LEngine.BuildPlan(
+      TRadIAProjectTemplateRequest.Create(
+        'HistoryCalculator',
+        ptkVcl,
+        '37.0',
+        ['Win32'],
+        '{"schemaVersion":2,"kind":"calculator",' +
+        '"creationProfile":"essential","features":{' +
+        '"operationHistory":{"enabled":true,"clearAction":true}}}'
+      )
+    );
+    try
+      LFoundDfm := False;
+      LFoundSource := False;
+      for LFile in LPlan.Files do
+      begin
+        if SameText(LFile.RelativePath, 'MainForm.dfm') then
+        begin
+          LFoundDfm := True;
+          Assert.Contains(LFile.Content, 'object OperationHistory: TListBox');
+          Assert.Contains(LFile.Content, 'object HistoryStatus: TEdit');
+          Assert.Contains(LFile.Content, 'object ClearHistoryButton: TButton');
+          Assert.Contains(LFile.Content, 'OnClick = ClearHistoryClick');
+        end;
+        if SameText(LFile.RelativePath, 'MainForm.pas') then
+        begin
+          LFoundSource := True;
+          Assert.Contains(LFile.Content, 'procedure TRadIAMainForm.AddHistoryEntry');
+          Assert.Contains(LFile.Content, 'OperationHistory.Items.Add(HistoryStatus.Text)');
+          Assert.Contains(LFile.Content, 'HistoryStatus.Clear');
+          Assert.Contains(LFile.Content, 'AddHistoryEntry(LLeft, LOperator');
+          Assert.Contains(LFile.Content, 'OperationHistory.Clear');
+          Assert.Contains(LFile.Content, 'if FPendingOperator = '''' then');
+        end;
+      end;
+      Assert.IsTrue(LFoundDfm);
+      Assert.IsTrue(LFoundSource);
+      Assert.Contains(LPlan.PreviewJson, '"operationHistory"');
     finally
       LPlan.Free;
     end;

--- a/Tests/Usage/release-promises.json
+++ b/Tests/Usage/release-promises.json
@@ -23,6 +23,16 @@
       "scenarioId": "natural-vcl-project-creation"
     },
     {
+      "id": "calculator-requirement-fidelity",
+      "publicStatement": "A calculator requested with operation history records calculations and clears the history.",
+      "priority": "critical",
+      "maximumDurationSeconds": 300,
+      "expectedOutcomes": ["history-request-preserved", "operation-recorded", "history-cleared"],
+      "forbiddenOutcomes": ["basic-calculator-substitution", "false-success-message", "step-limit-reached"],
+      "requiredTargets": ["delphi12-win32", "delphi13-win32", "delphi13-ide64"],
+      "scenarioId": "calculator-history-fidelity"
+    },
+    {
       "id": "build-failure-repair",
       "publicStatement": "The agent reproduces and repairs a compiler failure and proves the successful rebuild.",
       "priority": "critical",

--- a/Tests/Usage/usage-matrix.json
+++ b/Tests/Usage/usage-matrix.json
@@ -22,6 +22,7 @@
         "clean-install-and-upgrade",
         "agent-step-budget",
         "natural-vcl-project-creation",
+        "calculator-history-fidelity",
         "build-failure-repair",
         "dunitx-create-run-repair",
         "project-session-isolation",
@@ -337,6 +338,8 @@
         "project-created-and-opened",
         "calculator-built-and-started",
         "primary-calculation-observed",
+        "operation-history-recorded",
+        "history-clear-verified",
         "knowledge-index-ready-before-document-read",
         "clean-shutdown"
       ],
@@ -344,6 +347,30 @@
         "phases.projectCreated",
         "phases.buildPassed",
         "debugger.runtimeScenarioPassed",
+        "debugger.operationHistoryPassed",
+        "phases.shutdownPassed"
+      ]
+    },
+    {
+      "id": "calculator-history-fidelity",
+      "scope": "user-journey",
+      "runner": "Test-RadIA.NaturalVclCreationE2E.ps1",
+      "targetIds": [
+        "delphi12-win32",
+        "delphi13-win32",
+        "delphi13-ide64"
+      ],
+      "observableOutcomes": [
+        "history-request-preserved",
+        "operation-history-recorded",
+        "history-clear-verified",
+        "clean-shutdown"
+      ],
+      "requiredEvidence": [
+        "phases.projectCreated",
+        "phases.buildPassed",
+        "debugger.runtimeScenarioPassed",
+        "debugger.operationHistoryPassed",
         "phases.shutdownPassed"
       ]
     },

--- a/Tests/Web/RadIA.ReleasePromiseCoverage.test.js
+++ b/Tests/Web/RadIA.ReleasePromiseCoverage.test.js
@@ -17,6 +17,7 @@ test('critical public promises have stable user-journey identifiers', () => {
     [
       'direct-conversational-answer',
       'natural-vcl-project-creation',
+      'calculator-requirement-fidelity',
       'build-failure-repair',
       'dunitx-create-run-repair',
       'chat-window-state-persistence',

--- a/Tests/Web/RadIA.UsageMatrix.test.js
+++ b/Tests/Web/RadIA.UsageMatrix.test.js
@@ -124,7 +124,7 @@ test('release usage plan separates host contracts from IDE journeys', () => {
   const intentRuns = plan.runs.filter(
     (run) => run.scenarioId === 'intent-recommendation'
   );
-  assert.equal(plan.runCount, 46);
+  assert.equal(plan.runCount, 49);
   assert.equal(intentRuns.length, 1);
   assert.equal(intentRuns[0].targetId, 'host-neutral');
   assert.ok(intentRuns[0].requiredEvidence.includes('chat-fallback'));
@@ -148,6 +148,14 @@ test('release usage plan separates host contracts from IDE journeys', () => {
   assert.ok(
     creationRuns.every((run) => run.requiredEvidence.includes('phases.buildPassed'))
   );
+  const historyRuns = plan.runs.filter(
+    (run) => run.scenarioId === 'calculator-history-fidelity'
+  );
+  assert.equal(historyRuns.length, 3);
+  assert.ok(historyRuns.every((run) => run.scope === 'user-journey'));
+  assert.ok(historyRuns.every(
+    (run) => run.requiredEvidence.includes('debugger.operationHistoryPassed')
+  ));
   const problemRuns = plan.runs.filter(
     (run) => run.scenarioId === 'unified-problems-panel'
   );

--- a/docs/development/usage_test_matrix.en.md
+++ b/docs/development/usage_test_matrix.en.md
@@ -82,6 +82,8 @@ This command composes the following gates without options to skip their main req
 2. run every registered integration and end-to-end scenario applicable to supported targets;
 3. generate and build every supported template on Delphi 12 and 13;
 4. perform the visual `2 + 3 = 5` operation in the VCL calculator;
+   the scenario also proves that a history request records `2 + 3 = 5` in the list and that clearing
+   leaves the list empty;
 5. run all five calculator DUnitX tests;
 6. create, open, and immediately navigate a project on all three IDE targets;
 7. explicitly install the current build and run the startup/shutdown matrix on all three targets;

--- a/docs/development/usage_test_matrix.md
+++ b/docs/development/usage_test_matrix.md
@@ -82,6 +82,8 @@ Esse comando compõe, sem opções para pular os gates principais:
 2. todos os cenários registrados de integração e ponta a ponta aplicáveis aos alvos suportados;
 3. geração e build de todos os templates suportados no Delphi 12 e 13;
 4. operação visual `2 + 3 = 5` na calculadora VCL;
+   o cenário também comprova que o pedido de histórico gera `2 + 3 = 5` na lista e que a ação de
+   limpeza deixa a lista vazia;
 5. execução dos cinco testes DUnitX da calculadora;
 6. criação, abertura e navegação imediata de projeto nos três alvos da IDE;
 7. instalação explícita do build atual e matriz de inicialização/encerramento nos três alvos;

--- a/docs/guides/mcp_integration_guide.en.md
+++ b/docs/guides/mcp_integration_guide.en.md
@@ -195,7 +195,7 @@ For reproducible automation, prefer `mcp.<pid>.json`.
 1. Open Delphi and a project.
 2. Confirm that `mcp.<pid>.json` exists.
 3. Start or reload the MCP server in the client.
-4. Verify that `initialize` reports RadIA `2.17.4`.
+4. Verify that `initialize` reports RadIA `2.17.5`.
 5. Call `tools/list`.
 6. Call `GetIDEState` and `GetActiveProject`.
 7. Test mutable consent only in a disposable project.

--- a/docs/guides/mcp_integration_guide.md
+++ b/docs/guides/mcp_integration_guide.md
@@ -215,7 +215,7 @@ Para automação reproduzível, prefira sempre `mcp.<pid>.json`.
 1. Abra o Delphi e um projeto.
 2. Confirme que `mcp.<pid>.json` foi criado.
 3. Inicie ou recarregue o servidor no cliente MCP.
-4. Verifique que `initialize` retorna RadIA `2.17.4`.
+4. Verifique que `initialize` retorna RadIA `2.17.5`.
 5. Execute `tools/list`.
 6. Chame `GetIDEState` e `GetActiveProject`.
 7. Para testar consentimento, use uma tool mutável somente em um projeto descartável.

--- a/docs/guides/project_wizard.en.md
+++ b/docs/guides/project_wizard.en.md
@@ -92,3 +92,8 @@ the `dunitx` option, adds the companion project, exposes its executable in the p
 the five operation and division-by-zero tests through the RadIA runner. These extras are included
 only after an explicit user request or choice. The current matrix covers Delphi 12 Win32 and Delphi
 13 Win32/IDE64.
+
+The calculator specification accepts `schemaVersion: 2` and the `features.operationHistory`
+feature. When `enabled` is true, preview and creation preserve the operation list and its clear
+action. The release matrix runs the application, records `2 + 3 = 5` in history, and confirms that
+**Clear history** leaves the list empty on all three supported targets.

--- a/docs/guides/project_wizard.md
+++ b/docs/guides/project_wizard.md
@@ -98,3 +98,8 @@ gera e compila somente a aplicação solicitada. O perfil `complete`, ou o perfi
 `dunitx`, acrescenta o projeto companion, expõe seu executável no preview e permite executar os cinco
 testes de operações e divisão por zero pelo runner do RadIA. Esses adicionais só entram após pedido
 ou escolha explícita do usuário. A matriz vigente abrange Delphi 12 Win32 e Delphi 13 Win32/IDE64.
+
+A especificação de calculadora aceita `schemaVersion: 2` e o recurso
+`features.operationHistory`. Quando `enabled` é verdadeiro, preview e criação preservam a lista de
+operações e a ação de limpeza. A matriz de release executa a aplicação, registra `2 + 3 = 5` no
+histórico e confirma que **Clear history** deixa a lista vazia nos três alvos suportados.

--- a/docs/guides/user_guide_editor_generation.en.md
+++ b/docs/guides/user_guide_editor_generation.en.md
@@ -98,6 +98,8 @@ and platform — before showing the approval plan.
 2. The AI processes the request and returns the complete file set (project `.dpr`, configuration
    `.dproj`, logic units `.pas`, and UI forms `.dfm`). For VCL calculators, the native composer
    provides a functional display, keypad, and basic operations.
+   If the request mentions history, the specification includes that feature explicitly and the project
+   receives an ordered operation list and a **Clear history** action.
 3. Rad IA will display a glassmorphism-styled panel showing the list of generated files.
 4. **Saving Workflow**:
    * Click **Criar Projeto e Abrir na IDE** (Create Project and Open in IDE) in the chat UI.

--- a/docs/guides/user_guide_editor_generation.md
+++ b/docs/guides/user_guide_editor_generation.md
@@ -98,6 +98,8 @@ pasta de destino e plataforma — antes de apresentar o plano para aprovação.
 2. A IA processará a requisição e retornará a lista completa de arquivos estruturados (projeto `.dpr`,
    configurações `.dproj`, unidades de lógica `.pas` e telas `.dfm`). Para calculadoras VCL, o
    compositor nativo já fornece visor, teclado e operações básicas funcionais.
+   Se o pedido mencionar histórico, a especificação inclui esse recurso explicitamente e o projeto
+   recebe uma lista ordenada de operações e a ação **Clear history**.
 3. O Rad IA exibirá um painel com estilo *glassmorphism* contendo a lista dos arquivos gerados.
 4. **Fluxo de Gravação**:
    * Clique em **Criar Projeto e Abrir na IDE** na UI do chat.

--- a/docs/guides/user_guide_journeys.en.md
+++ b/docs/guides/user_guide_journeys.en.md
@@ -73,6 +73,12 @@ explicit choices to keep the project as-is, add DUnitX, or request other increme
 choice does `complete`, or `custom` with `dunitx`, include `companionTestProject` and
 `companionTestExecutable`, build the companion suite, and run it with `RunDUnitXTests`.
 
+When the request includes **operation history**, **calculation list**, or an equivalent phrase, that
+requirement is preserved in the structured specification and preview. The generated calculator records
+each completed operation in order and provides **Clear history**. The journey can only complete after
+running real calculations, checking the history, and verifying that it can be cleared; a green build
+alone does not satisfy this request.
+
 ## Execution model
 
 1. The command visually enables agent mode when necessary.

--- a/docs/guides/user_guide_journeys.md
+++ b/docs/guides/user_guide_journeys.md
@@ -73,6 +73,12 @@ para manter o projeto como está, adicionar DUnitX ou solicitar outros increment
 escolha o perfil `complete`, ou `custom` com `dunitx`, inclui `companionTestProject` e
 `companionTestExecutable`, compila a suíte companion e executa os testes com `RunDUnitXTests`.
 
+Quando o pedido inclui **histórico de operações**, **lista de cálculos** ou expressão equivalente,
+esse requisito é preservado na especificação estruturada e no preview. A calculadora gerada registra
+cada operação concluída em ordem e oferece **Clear history**. A jornada só pode concluir depois de
+executar cálculos reais, conferir o histórico e verificar sua limpeza; um build verde, isoladamente,
+não atende esse pedido.
+
 ## Como a execução funciona
 
 1. O comando ativa visualmente o modo agente quando necessário.

--- a/docs/guides/user_manual.en.md
+++ b/docs/guides/user_manual.en.md
@@ -1,4 +1,4 @@
-# Complete RadIA 2.17.4 user manual
+# Complete RadIA 2.17.5 user manual
 
 > Use `/help` to compare Chat, Agent, CLI, and MCP. When a plan awaits approval, select
 > **Approve plan** or type `/agent resume`.
@@ -36,7 +36,7 @@ layouts such as `Startup Layout` and `Debug Layout`. If the panel is closed befo
 remains closed in the next session; use `Tools > RadIA > Chat` to open it again.
 
 The chat panel caption and primary RadIA windows show the loaded version, for example
-`Rad IA Chat v2.17.4`, so support can confirm the installed build quickly.
+`Rad IA Chat v2.17.5`, so support can confirm the installed build quickly.
 
 Supported credentials are protected locally with Windows DPAPI. Ollama and LM Studio can run
 locally. See the [installation guide](../getting-started/install_config.en.md).

--- a/docs/guides/user_manual.md
+++ b/docs/guides/user_manual.md
@@ -1,4 +1,4 @@
-# Manual completo do RadIA 2.17.4
+# Manual completo do RadIA 2.17.5
 
 > Para comparar Chat, Agent, CLI e MCP, use `/help`. Quando um plano aguardar aprovação, clique em
 > **Approve plan** ou digite `/agent resume`.
@@ -45,7 +45,7 @@ troca entre layouts nomeados, como `Startup Layout` e `Debug Layout`. Se o paine
 de sair, ele permanece fechado na sessão seguinte; use `Tools > RadIA > Chat` para abri-lo novamente.
 
 O caption do painel de chat e das janelas principais do RadIA mostra a versão carregada, por exemplo
-`Rad IA Chat v2.17.4`, para facilitar suporte e conferência de instalação.
+`Rad IA Chat v2.17.5`, para facilitar suporte e conferência de instalação.
 
 Se o painel ou package não aparecer:
 

--- a/docs/reference/cli_capability_matrix.en.md
+++ b/docs/reference/cli_capability_matrix.en.md
@@ -15,7 +15,7 @@
 
 ## Current matrix
 
-| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.4 use |
+| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.5 use |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Yes, JSONL | Structured event | `exec resume <id>` | Yes | Yes | Not declared | New execution per message |
 | Claude Code | Yes, stream JSON | Structured event | `--resume <id>` | Yes | Yes | Not declared | New execution per message |

--- a/docs/reference/cli_capability_matrix.md
+++ b/docs/reference/cli_capability_matrix.md
@@ -15,7 +15,7 @@
 
 ## Matriz atual
 
-| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.4 |
+| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.5 |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Sim, JSONL | Evento estruturado | `exec resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |
 | Claude Code | Sim, stream JSON | Evento estruturado | `--resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radia-plugin",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "description": "Rad IA - AI Assistant for Delphi IDE",
   "main": "eslint.config.js",
   "scripts": {

--- a/scripts/Test-RadIA.KnowledgeNotifierSmoke.ps1
+++ b/scripts/Test-RadIA.KnowledgeNotifierSmoke.ps1
@@ -1397,9 +1397,15 @@ try {
             platforms = @("Win32")
             destinationPath = $generatedProjectDirectory
             projectSpecification = @{
-                schemaVersion = 1
+                schemaVersion = 2
                 kind = "calculator"
                 creationProfile = "complete"
+                features = @{
+                    operationHistory = @{
+                        enabled = $true
+                        clearAction = $true
+                    }
+                }
             }
         }
     if (-not $templatePreview.previewId) {
@@ -1935,7 +1941,7 @@ try {
             if (-not $calculatorWindow -or -not $controlTree) {
                 throw "The calculator control tree was not discovered."
             }
-            $requiredControls = @("2", "+", "3", "=")
+            $requiredControls = @("2", "+", "3", "=", "Clear history")
             $controlsByText = @{}
             foreach ($controlText in $requiredControls) {
                 $control = @(
@@ -2015,6 +2021,74 @@ try {
                     ($scenarioResult | ConvertTo-Json -Depth 8 -Compress)
                 )
             }
+            $controlTree = Invoke-RadIATool `
+                -BridgePath $bridgePath `
+                -InstanceFile $instanceFile `
+                -Name "GetRuntimeControlTree" `
+                -Arguments @{ windowId = $calculatorWindow.windowId }
+            $historyControl = @(
+                $controlTree.controls |
+                    Where-Object {
+                        $_.className -eq "TEdit" -and
+                        $_.text -eq "2 + 3 = 5"
+                    }
+            ) | Select-Object -First 1
+            if (-not $historyControl) {
+                throw (
+                    "The calculator did not preserve the requested operation history: " +
+                    $(if ($historyControl) { $historyControl.text } else { "missing" })
+                )
+            }
+            $clearPreview = Invoke-RadIATool `
+                -BridgePath $bridgePath `
+                -InstanceFile $instanceFile `
+                -Name "PrepareRuntimeScenario" `
+                -Arguments @{
+                    name = "Clear calculator operation history"
+                    limits = @{
+                        maxActions = 2
+                        maxDurationMs = 5000
+                        maxRepetitions = 1
+                    }
+                    actions = @(
+                        @{
+                            kind = "invoke"
+                            targetId = $controlsByText["Clear history"].controlId
+                            timeoutMs = 1000
+                        },
+                        @{
+                            kind = "wait"
+                            timeoutMs = 250
+                        }
+                    )
+                }
+            $clearResult = Invoke-RadIAToolWithConsent `
+                -BridgePath $bridgePath `
+                -InstanceFile $instanceFile `
+                -IDEProcess $process `
+                -Name "RunRuntimeScenario" `
+                -Arguments @{ previewId = $clearPreview.previewId }
+            if ($clearResult.state -ne "succeeded") {
+                throw "The calculator history clear scenario failed."
+            }
+            $controlTree = Invoke-RadIATool `
+                -BridgePath $bridgePath `
+                -InstanceFile $instanceFile `
+                -Name "GetRuntimeControlTree" `
+                -Arguments @{ windowId = $calculatorWindow.windowId }
+            $historyControl = @(
+                $controlTree.controls |
+                    Where-Object {
+                        $_.className -eq "TEdit" -and
+                        $_.text -eq ""
+                    }
+            ) | Select-Object -First 1
+            if (-not $historyControl -or $historyControl.text -ne "") {
+                throw (
+                    "The calculator operation history was not cleared: " +
+                    $(if ($historyControl) { $historyControl.text } else { "missing" })
+                )
+            }
             $stopResult = Invoke-RadIAToolWithConsent `
                 -BridgePath $bridgePath `
                 -InstanceFile $instanceFile `
@@ -2039,6 +2113,7 @@ try {
             callStackFrameCount = $callStack.frames.Count
             timelineEventCount = $timeline.events.Count
             runtimeScenarioPassed = $ExerciseCalculatorRuntime.IsPresent
+            operationHistoryPassed = $ExerciseCalculatorRuntime.IsPresent
             runtimeControlCount = if ($ExerciseCalculatorRuntime) {
                 $controlTree.count
             } else {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # SonarQube Project Configuration
 sonar.projectKey=radia
 sonar.projectName=radia
-sonar.projectVersion=2.17.4
+sonar.projectVersion=2.17.5
 
 # Path to the source directories
 sonar.sources=Source


### PR DESCRIPTION
## Resumo\n\nLibera o RadIA 2.17.5 com preservação ponta a ponta de requisitos funcionais na criação de calculadoras com histórico.\n\n## Principais correções\n\n- histórico de operações preservado na intenção, especificação, preview e projeto gerado\n- registro funcional, último cálculo observável e limpeza do histórico\n- planos específicos ao objetivo em vez de aprovação genérica de inspeção\n- bloqueio imediato de leitura idêntica do mesmo intervalo de artefato\n- nova promessa pública e E2E obrigatório nos três alvos suportados\n\n## Gates aprovados em develop/e0a252c6\n\n- SonarQube Quality Gate: OK\n- Delphi 12: 1408/1408 + 8/8\n- Delphi 13: 1408/1408 + 8/8\n- matriz integral: 49 execuções aprovadas\n- E2E de histórico: Delphi 12 Win32, Delphi 13 Win32 e Delphi 13 IDE64\n- lint, documentação e 206 testes web aprovados