### PR TITLE
test: Stabilize Delphi window lifecycle journeys

### DIFF
--- a/Tests/Web/RadIA.UsageMatrix.test.js
+++ b/Tests/Web/RadIA.UsageMatrix.test.js
@@ -13,6 +13,11 @@ const releaseRunnerPath = path.join(
   'Test-RadIA.ReleaseUsage.ps1'
 );
 const buildPath = path.join(root, 'build.ps1');
+const smokeRunnerPath = path.join(
+  root,
+  'scripts',
+  'Test-RadIA.KnowledgeNotifierSmoke.ps1'
+);
 
 test('usage matrix covers every supported IDE target', () => {
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
@@ -61,6 +66,7 @@ test('release gate composes calculator, opening, and usage tests', () => {
   const source = fs.readFileSync(releaseRunnerPath, 'utf8');
   const matrixSource = fs.readFileSync(runnerPath, 'utf8');
   const buildSource = fs.readFileSync(buildPath, 'utf8');
+  const smokeSource = fs.readFileSync(smokeRunnerPath, 'utf8');
   assert.match(source, /build\.ps1/u);
   assert.match(source, /-Test/u);
   assert.match(source, /Version = "23\.0"/u);
@@ -85,6 +91,10 @@ test('release gate composes calculator, opening, and usage tests', () => {
   assert.match(source, /attemptCount/u);
   assert.match(source, /Delphi did not become ready for the smoke test/u);
   assert.match(source, /The Delphi File menu did not open/u);
+  assert.match(smokeSource, /\$attempt -le 3 -and -not \$menuOpened/u);
+  assert.match(smokeSource, /SetForegroundWindow\(\$mainWindow\)/u);
+  assert.match(smokeSource, /TRadIAOnboardingForm/u);
+  assert.match(smokeSource, /\$onboardingWindow/u);
   assert.match(source, /The Delphi file dialog did not open/u);
   assert.match(source, /Test-RadIAReleaseJourneyRetryable/u);
   assert.match(source, /previousErrorActionPreference/u);

--- a/scripts/Test-RadIA.KnowledgeNotifierSmoke.ps1
+++ b/scripts/Test-RadIA.KnowledgeNotifierSmoke.ps1
@@ -292,24 +292,36 @@ function Invoke-RadIAFileMenuCommand {
         throw "The Delphi File menu is not available."
     }
     $mousePosition = [IntPtr]((12 -shl 16) -bor 12)
-    [void][RadIAWindowNative]::PostMessage(
-        $menuBar,
-        0x0201,
-        [IntPtr]1,
-        $mousePosition
-    )
-    [void][RadIAWindowNative]::PostMessage(
-        $menuBar,
-        0x0202,
-        [IntPtr]0,
-        $mousePosition
-    )
-    Wait-RadIACondition -TimeoutSeconds 5 -Condition {
-        [RadIAWindowNative]::FindVisibleWindow(
-            [uint32]$Process.Id,
-            "TIDEStylePopupMenu"
-        ) -ne [IntPtr]::Zero
-    } -FailureMessage "The Delphi File menu did not open."
+    $menuOpened = $false
+    for ($attempt = 1; $attempt -le 3 -and -not $menuOpened; $attempt++) {
+        [void][RadIAWindowNative]::SetForegroundWindow($mainWindow)
+        Start-Sleep -Milliseconds 250
+        [void][RadIAWindowNative]::PostMessage(
+            $menuBar,
+            0x0201,
+            [IntPtr]1,
+            $mousePosition
+        )
+        [void][RadIAWindowNative]::PostMessage(
+            $menuBar,
+            0x0202,
+            [IntPtr]0,
+            $mousePosition
+        )
+        $menuDeadline = [DateTime]::UtcNow.AddSeconds(5)
+        while ([DateTime]::UtcNow -lt $menuDeadline -and -not $menuOpened) {
+            $menuOpened = [RadIAWindowNative]::FindVisibleWindow(
+                [uint32]$Process.Id,
+                "TIDEStylePopupMenu"
+            ) -ne [IntPtr]::Zero
+            if (-not $menuOpened) {
+                Start-Sleep -Milliseconds 250
+            }
+        }
+    }
+    if (-not $menuOpened) {
+        throw "The Delphi File menu did not open after 3 attempts."
+    }
 
     if ($AccessKey) {
         $virtualKey = [int][char]$AccessKey.ToUpperInvariant()
@@ -2783,6 +2795,19 @@ try {
         -ErrorAction SilentlyContinue
     if ($remainingProcess) {
         if ($remainingProcess.MainWindowHandle -ne [IntPtr]::Zero) {
+            $onboardingWindow = [RadIAWindowNative]::FindVisibleWindow(
+                [uint32]$process.Id,
+                "TRadIAOnboardingForm"
+            )
+            if ($onboardingWindow -ne [IntPtr]::Zero) {
+                [void][RadIAWindowNative]::PostMessage(
+                    $onboardingWindow,
+                    0x0010,
+                    [IntPtr]0,
+                    [IntPtr]0
+                )
+                Start-Sleep -Milliseconds 250
+            }
             [void]$remainingProcess.CloseMainWindow()
             if (-not $remainingProcess.WaitForExit(3000)) {
                 $shutdownDeadline = [DateTime]::UtcNow.AddSeconds(


### PR DESCRIPTION
## Resumo\n\n- torna a abertura do menu File resiliente a atrasos de foco na IDE\n- fecha o onboarding do RadIA antes de validar o shutdown limpo\n- adiciona testes estruturais para as duas proteções\n\n## Validação\n\n- ESLint\n- teste estrutural da matriz E2E: 4/4\n- calculadora com histórico no Delphi 13 Win32: aprovado, incluindo shutdown limpo