### PR TITLE
test: Add tiered release validation profiles

### DIFF
--- a/Tests/Usage/usage-matrix.json
+++ b/Tests/Usage/usage-matrix.json
@@ -10,7 +10,30 @@
     },
     {
       "id": "release",
-      "description": "Runs IDE lifecycle and critical user-facing capability contracts.",
+      "description": "Runs the bounded release-critical journeys on the representative IDE target.",
+      "targetIds": [
+        "delphi13-win32"
+      ],
+      "scenarioIds": [
+        "first-conversation",
+        "chat-window-state-persistence",
+        "clean-install-and-upgrade",
+        "natural-vcl-project-creation",
+        "calculator-history-fidelity",
+        "intent-recommendation",
+        "unified-problems-panel",
+        "semantic-hierarchy-refactoring",
+        "advanced-breakpoints"
+      ]
+    },
+    {
+      "id": "targeted",
+      "description": "Runs only explicitly selected scenarios on compatible targets.",
+      "scenarioIds": []
+    },
+    {
+      "id": "regression",
+      "description": "Runs every registered scenario on every compatible IDE target.",
       "scenarioIds": [
         "ide-startup-shutdown",
         "first-conversation",

--- a/Tests/Web/RadIA.Documentation.test.js
+++ b/Tests/Web/RadIA.Documentation.test.js
@@ -614,7 +614,7 @@ test('current release gates use the generated catalog size', () => {
   });
 });
 
-test('release keeps integration, calculator, and project journeys indivisible', () => {
+test('release documents bounded, targeted, and regression gates', () => {
   const portuguese = fs.readFileSync(documentationPath('release_process.md'), 'utf8');
   const english = fs.readFileSync(documentationPath('release_process.en.md'), 'utf8');
   const usageMatrix = fs.readFileSync(documentationPath('usage_test_matrix.md'), 'utf8');
@@ -623,14 +623,16 @@ test('release keeps integration, calculator, and project journeys indivisible', 
     'utf8'
   );
 
-  assert.match(portuguese, /toda a suíte registrada de integração e ponta a ponta/u);
-  assert.match(english, /entire registered integration and end-to-end suite/u);
-  assert.match(usageMatrix, /sem opções para pular os gates principais/u);
-  assert.match(usageMatrix, /não aceita filtro, exclusão ou aprovação parcial/u);
+  assert.match(portuguese, /certificação `regression`/u);
+  assert.match(english, /`regression` certification/u);
+  assert.match(usageMatrix, /Todos os 49 fluxos/u);
+  assert.match(usageMatrix, /-Profile targeted/u);
+  assert.match(usageMatrix, /-Profile regression/u);
   assert.match(releaseRunner, /build\.ps1[\s\S]*-Test/u);
   assert.match(releaseRunner, /Test-RadIA\.GeneratedProjects\.ps1/u);
-  assert.match(releaseRunner, /Test-RadIA\.ProjectCreationNavigation\.ps1/u);
   assert.match(releaseRunner, /Test-RadIA\.UsageMatrix\.ps1/u);
+  assert.match(releaseRunner, /-Profile "startup"/u);
+  assert.match(releaseRunner, /-Profile "release"/u);
 });
 
 test('release metadata and operational protocols follow the package version', () => {

--- a/Tests/Web/RadIA.ReleasePromiseCoverage.test.js
+++ b/Tests/Web/RadIA.ReleasePromiseCoverage.test.js
@@ -47,6 +47,6 @@ test('promise gate rejects contracts disguised as user E2E evidence', () => {
   assert.match(gate, /maximum-duration-missing/u);
   assert.match(gate, /expected-outcomes-missing/u);
   assert.match(gate, /forbidden-outcomes-missing/u);
-  assert.match(gate, /scenario-not-required-by-release/u);
+  assert.match(gate, /scenario-not-required-by-regression/u);
   assert.match(gate, /Release promises without mandatory user-journey E2E coverage/u);
 });

--- a/Tests/Web/RadIA.UsageMatrix.test.js
+++ b/Tests/Web/RadIA.UsageMatrix.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
-const { execFileSync } = require('node:child_process');
+const { execFileSync, spawnSync } = require('node:child_process');
 const test = require('node:test');
 
 const root = path.resolve('.');
@@ -62,7 +62,7 @@ test('usage matrix plan is deterministic and does not start Delphi', () => {
   );
 });
 
-test('release gate composes calculator, opening, and usage tests', () => {
+test('release gate composes bounded critical validation', () => {
   const source = fs.readFileSync(releaseRunnerPath, 'utf8');
   const matrixSource = fs.readFileSync(runnerPath, 'utf8');
   const buildSource = fs.readFileSync(buildPath, 'utf8');
@@ -73,43 +73,33 @@ test('release gate composes calculator, opening, and usage tests', () => {
   assert.match(source, /Version = "37\.0"/u);
   assert.match(source, /Test-RadIA\.GeneratedProjects\.ps1/u);
   assert.match(source, /New-RadIA\.GeneratedProjectsEvidence\.ps1/u);
-  assert.match(source, /Test-RadIA\.ProjectCreationNavigation\.ps1/u);
   assert.match(source, /Test-RadIA\.ReleasePromises\.ps1/u);
   assert.match(source, /-Enforce/u);
   assert.match(source, /Test-RadIA\.UsageMatrix\.ps1/u);
+  assert.match(source, /-Profile "startup"/u);
   assert.match(source, /-Profile "release"/u);
+  assert.match(source, /\[switch\]\$PlanOnly/u);
+  assert.match(source, /totalIdeRunCount/u);
   assert.doesNotMatch(source, /RequirePackageProvenance/u);
-  assert.match(source, /installationTargets/u);
-  assert.match(source, /Install = \$true/u);
+  assert.doesNotMatch(source, /installationTargets/u);
+  assert.doesNotMatch(source, /openingTargets/u);
   assert.match(source, /Stop-RadIAReleaseAuxiliaryProcesses/u);
   assert.match(source, /Where-Object \{ -not \$_\.HasExited \}/u);
   assert.match(matrixSource, /Where-Object \{ -not \$_\.HasExited \}/u);
+  assert.match(
+    matrixSource,
+    /\$Profile -in @\("startup", "release", "regression"\)/u
+  );
   assert.match(buildSource, /function Copy-RadIAReplaceableFile/u);
   assert.match(buildSource, /\.pending-delete-\$PID-/u);
   assert.match(source, /RadIA\.Semantic\.Engine/u);
-  assert.match(source, /startupRetryUsed/u);
-  assert.match(source, /attemptCount/u);
-  assert.match(source, /Delphi did not become ready for the smoke test/u);
-  assert.match(source, /The Delphi File menu did not open/u);
   assert.match(smokeSource, /\$attempt -le 3 -and -not \$menuOpened/u);
   assert.match(smokeSource, /SetForegroundWindow\(\$mainWindow\)/u);
   assert.match(smokeSource, /TRadIAOnboardingForm/u);
   assert.match(smokeSource, /\$onboardingWindow/u);
-  assert.match(source, /The Delphi file dialog did not open/u);
-  assert.match(source, /Test-RadIAReleaseJourneyRetryable/u);
-  assert.match(source, /previousErrorActionPreference/u);
-  assert.match(source, /\$ErrorActionPreference = "Continue"/u);
-  assert.ok(
-    source.indexOf('$installationTargets = @(') <
-      source.indexOf('$openingTargets = @(')
-  );
-  const retryStart = source.indexOf('$firstAttemptOutput = $output');
-  const retryEnd = source.indexOf('$attemptCount = 2', retryStart);
-  const retryBlock = source.slice(retryStart, retryEnd);
-  assert.match(retryBlock, /Install-RadIAReleaseTarget/u);
 });
 
-test('release usage plan separates host contracts from IDE journeys', () => {
+test('release usage plan is bounded to the representative target', () => {
   const output = execFileSync(
     'powershell.exe',
     [
@@ -125,43 +115,32 @@ test('release usage plan separates host contracts from IDE journeys', () => {
     { encoding: 'utf8' }
   );
   const plan = JSON.parse(output);
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-  assert.equal(plan.scenarioCount, manifest.scenarios.length);
-  assert.deepEqual(
-    [...new Set(plan.runs.map((run) => run.scenarioId))].sort(),
-    manifest.scenarios.map((scenario) => scenario.id).sort()
-  );
+  assert.equal(plan.targetCount, 1);
+  assert.equal(plan.scenarioCount, 9);
+  assert.equal(plan.runCount, 9);
   const intentRuns = plan.runs.filter(
     (run) => run.scenarioId === 'intent-recommendation'
   );
-  assert.equal(plan.runCount, 49);
   assert.equal(intentRuns.length, 1);
   assert.equal(intentRuns[0].targetId, 'host-neutral');
   assert.ok(intentRuns[0].requiredEvidence.includes('chat-fallback'));
   const conversationRuns = plan.runs.filter(
     (run) => run.scenarioId === 'first-conversation'
   );
-  assert.equal(conversationRuns.length, 3);
+  assert.equal(conversationRuns.length, 1);
+  assert.equal(conversationRuns[0].targetId, 'delphi13-win32');
   assert.ok(conversationRuns.every((run) => run.scope === 'user-journey'));
   const windowStateRuns = plan.runs.filter(
     (run) => run.scenarioId === 'chat-window-state-persistence'
   );
-  assert.equal(windowStateRuns.length, 3);
+  assert.equal(windowStateRuns.length, 1);
   assert.ok(windowStateRuns.every(
     (run) => run.requiredEvidence.includes('boundsRestored')
   ));
-  const creationRuns = plan.runs.filter(
-    (run) => run.scenarioId === 'vcl-project-creation-lifecycle'
-  );
-  assert.equal(creationRuns.length, 3);
-  assert.ok(creationRuns.every((run) => run.scope === 'ide-journey'));
-  assert.ok(
-    creationRuns.every((run) => run.requiredEvidence.includes('phases.buildPassed'))
-  );
   const historyRuns = plan.runs.filter(
     (run) => run.scenarioId === 'calculator-history-fidelity'
   );
-  assert.equal(historyRuns.length, 3);
+  assert.equal(historyRuns.length, 1);
   assert.ok(historyRuns.every((run) => run.scope === 'user-journey'));
   assert.ok(historyRuns.every(
     (run) => run.requiredEvidence.includes('debugger.operationHistoryPassed')
@@ -189,5 +168,57 @@ test('release usage plan separates host contracts from IDE journeys', () => {
     breakpointRuns[0].requiredEvidence.includes(
       'unsupported-exception-filter-explicit'
     )
+  );
+});
+
+test('regression plan retains every scenario on compatible targets', () => {
+  const output = execFileSync(
+    'powershell.exe',
+    [
+      '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', runnerPath,
+      '-Profile', 'regression', '-PlanOnly'
+    ],
+    { encoding: 'utf8' }
+  );
+  const plan = JSON.parse(output);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  assert.equal(plan.scenarioCount, manifest.scenarios.length);
+  assert.equal(plan.runCount, 49);
+  assert.deepEqual(
+    [...new Set(plan.runs.map((run) => run.scenarioId))].sort(),
+    manifest.scenarios.map((scenario) => scenario.id).sort()
+  );
+});
+
+test('targeted plan runs only explicit scenarios and targets', () => {
+  const output = execFileSync(
+    'powershell.exe',
+    [
+      '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', runnerPath,
+      '-Profile', 'targeted', '-ScenarioId', 'calculator-history-fidelity',
+      '-TargetId', 'delphi13-win32', '-PlanOnly'
+    ],
+    { encoding: 'utf8' }
+  );
+  const plan = JSON.parse(output);
+  assert.equal(plan.scenarioCount, 1);
+  assert.equal(plan.runCount, 1);
+  assert.equal(plan.runs[0].scenarioId, 'calculator-history-fidelity');
+  assert.equal(plan.runs[0].targetId, 'delphi13-win32');
+});
+
+test('targeted plan rejects an implicit broad selection', () => {
+  const result = spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', runnerPath,
+      '-Profile', 'targeted', '-PlanOnly'
+    ],
+    { encoding: 'utf8' }
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(
+    `${result.stdout}${result.stderr}`,
+    /targeted profile requires at least one -ScenarioId/u
   );
 });

--- a/docs/development/move_type_contract.en.md
+++ b/docs/development/move_type_contract.en.md
@@ -56,4 +56,4 @@ content while the preview remains valid.
 - proven rejection of DFM, private dependency, cycle, and stale revision;
 - application and rollback with exact equality to the original files;
 - Delphi 12 and 13 builds and tests;
-- an integration scenario registered in the indivisible release gate.
+- an integration scenario registered in the targeted gate and full regression.

--- a/docs/development/move_type_contract.md
+++ b/docs/development/move_type_contract.md
@@ -56,4 +56,4 @@ anterior enquanto o preview permanecer válido.
 - rejeição comprovada de DFM, dependência privada, ciclo e revisão obsoleta;
 - aplicação e rollback com igualdade exata dos arquivos originais;
 - build e testes no Delphi 12 e 13;
-- cenário de integração registrado no gate indivisível de release.
+- cenário de integração registrado no gate direcionado e na regressão completa.

--- a/docs/development/release_process.en.md
+++ b/docs/development/release_process.en.md
@@ -28,15 +28,15 @@ node --test --test-isolation=none Tests/Web/RadIA.Documentation.test.js
 powershell.exe -ExecutionPolicy Bypass -File scripts\Test-RadIA.ReleaseUsage.ps1
 ```
 
-`Test-RadIA.ReleaseUsage.ps1` is mandatory for every release and runs, as one indivisible gate, the
-validation that every critical public promise has a real E2E journey on every supported target,
-complete DUnitX suites on Delphi 12 and 13, the entire registered integration and end-to-end suite,
-calculator creation plus its functional and DUnitX tests, immediate project creation and opening, and
-the automated usage matrix on Delphi 12 Win32, Delphi 13 Win32, and Delphi 13 IDE64. It produces
-sanitized evidence under `Output/Validation/ReleaseUsage`; a missing, skipped, or failed group, target,
-or scenario blocks publication. Do not run or approve these groups in isolation to authorize a release.
-The `release` profile must include every scenario registered in `Tests/Usage/usage-matrix.json`; the
-runner stops when it finds a registered scenario outside that profile.
+`Test-RadIA.ReleaseUsage.ps1` is mandatory for every release. It runs complete DUnitX suites on Delphi
+12 and 13, every template, startup/shutdown smoke on all three targets, and critical journeys on the
+representative Delphi 13 Win32 target. It writes sanitized evidence under
+`Output/Validation/ReleaseUsage`; any executed step that fails blocks publication.
+
+The `regression` certification preserves all 49 flows on compatible targets but runs on demand. It is
+mandatory for major releases and changes to the installer, WebView2, shutdown, session isolation,
+security/consent, E2E infrastructure, or supported targets. During development use `targeted` with
+`-ScenarioId` and `-TargetId`. See [Automated usage test matrix](usage_test_matrix.en.md).
 
 Run the scanner **locally** and require a passing Quality Gate for the same revision. Builds, tests,
 catalog, installer, and smoke tests must point to the same clean commit. Evidence must never be edited
@@ -44,8 +44,8 @@ manually to bypass a failure.
 
 Use Delphi 12 (`-DelphiVersion "23.0"`) for static scanning. The current Delphi analyzer cannot parse
 some newer Delphi 13 RTL constructs correctly and may report unused-symbol false positives. This choice
-affects only the static parser: the indivisible gate still builds, tests, and runs the journeys on Delphi
-12 Win32, Delphi 13 Win32, and Delphi 13 IDE64.
+affects only the static parser: the gate still builds and tests both Delphi versions and runs compatibility
+smoke on Delphi 12 Win32, Delphi 13 Win32, and Delphi 13 IDE64.
 
 The GitHub Actions `SonarQube release gate` workflow is an optional manual repetition that depends on an
 available registered Windows `self-hosted` runner. Pushes, pull requests, and tags do not start it. It

--- a/docs/development/release_process.md
+++ b/docs/development/release_process.md
@@ -28,15 +28,16 @@ node --test --test-isolation=none Tests/Web/RadIA.Documentation.test.js
 powershell.exe -ExecutionPolicy Bypass -File scripts\Test-RadIA.ReleaseUsage.ps1
 ```
 
-`Test-RadIA.ReleaseUsage.ps1` é obrigatório em toda release e executa, como um único gate indivisível,
-a validação de que cada promessa pública crítica possui uma jornada E2E real nos alvos suportados,
-as suítes DUnitX completas no Delphi 12 e 13, toda a suíte registrada de integração e ponta a ponta, a
-criação e os testes funcionais e DUnitX da calculadora, a criação e abertura imediata de projetos e a
-matriz automatizada de uso no Delphi 12 Win32, Delphi 13 Win32 e Delphi 13 IDE64. O gate produz evidência
-sanitizada em `Output/Validation/ReleaseUsage` e qualquer grupo, alvo ou cenário ausente, ignorado ou
-reprovado bloqueia a publicação. Não execute nem aprove esses grupos isoladamente para autorizar uma
-release. O perfil `release` deve incluir todos os cenários registrados em `Tests/Usage/usage-matrix.json`;
-o próprio runner interrompe a execução quando encontra um cenário cadastrado fora desse perfil.
+`Test-RadIA.ReleaseUsage.ps1` é obrigatório em toda release. Ele executa as suítes DUnitX completas no
+Delphi 12 e 13, todos os templates, smoke de startup/shutdown nos três alvos e as jornadas críticas no
+Delphi 13 Win32 representativo. O gate produz evidência sanitizada em `Output/Validation/ReleaseUsage` e
+qualquer etapa executada que reprove bloqueia a publicação.
+
+A certificação `regression` preserva todos os 49 fluxos nos alvos compatíveis, mas é executada sob demanda.
+Ela é obrigatória para releases maiores e mudanças no instalador, WebView2, shutdown, isolamento de sessão,
+segurança/consentimento, infraestrutura E2E ou suporte de targets. Durante o desenvolvimento, use o perfil
+`targeted` com `-ScenarioId` e `-TargetId`. Consulte
+[Matriz automatizada de testes de uso](usage_test_matrix.md) para a tabela de decisão e os comandos.
 
 Execute o scanner **localmente** e exija o Quality Gate aprovado para a mesma revisão. Builds, testes,
 catálogo, instalador e smokes devem apontar para o mesmo commit limpo. Nenhuma evidência deve ser
@@ -44,8 +45,8 @@ editada manualmente para contornar uma falha.
 
 Use o Delphi 12 (`-DelphiVersion "23.0"`) no scanner estático. O analisador Delphi atual não interpreta
 corretamente construções novas da RTL do Delphi 13 e pode produzir falsos positivos de símbolos não usados.
-Essa escolha limita somente o parser estático: o gate indivisível continua compilando, testando e executando
-as jornadas no Delphi 12 Win32, Delphi 13 Win32 e Delphi 13 IDE64.
+Essa escolha limita somente o parser estático: o gate continua compilando e testando os dois Delphis e
+executando o smoke de compatibilidade no Delphi 12 Win32, Delphi 13 Win32 e Delphi 13 IDE64.
 
 O workflow `SonarQube release gate` do GitHub Actions é uma repetição manual opcional, dependente de um
 runner Windows `self-hosted` registrado e disponível. Ele não é disparado por push, pull request ou tag,

--- a/docs/development/usage_test_matrix.en.md
+++ b/docs/development/usage_test_matrix.en.md
@@ -1,7 +1,7 @@
 # Automated usage test matrix
 
-The usage matrix validates RadIA as a product inside Delphi, complementing unit and Web tests. It is
-mandatory for every release and covers Delphi 12 Win32, Delphi 13 Win32, and Delphi 13 IDE64.
+The usage matrix validates RadIA as a product inside Delphi, complementing unit and Web tests. It has
+separate levels so routine delivery does not become a multi-hour certification.
 
 ## Layers
 
@@ -52,6 +52,18 @@ powershell.exe -ExecutionPolicy Bypass `
 `-PlanOnly` validates the manifest and returns JSON with every combination that would run. It does
 not start, install, or modify the IDE.
 
+## Execution levels
+
+| Level | When to use | Coverage |
+|---|---|---|
+| `release` | Every patch or minor publication | Complete suites, templates, startup on three targets, and critical journeys on Delphi 13 Win32 |
+| `targeted` | Development and localized fixes | Only explicitly selected scenarios and targets |
+| `regression` | Major releases, cross-cutting changes, or instability investigations | All 49 flows on every compatible target |
+
+Run `regression` for changes to the installer, WebView2 lifecycle, IDE shutdown, session isolation,
+security/consent, E2E orchestration, or the target matrix. Also run it before a major release, after a
+failure that cannot be isolated, or when targeted selection cannot safely represent the changed surface.
+
 ## Run during development
 
 Close every Delphi instance and run:
@@ -62,10 +74,26 @@ powershell.exe -ExecutionPolicy Bypass `
   -Profile startup
 ```
 
-The aggregate result is written to `Output/Validation/UsageMatrix/usage-matrix.json`. In the `release`
-profile, the orchestrator groups journeys by target and installs the matching package before running them. During
+The aggregate result is written to `Output/Validation/UsageMatrix/usage-matrix.json`. The `release`
+profile runs critical journeys on Delphi 13 Win32. During
 development, evidence reports a dirty source and no required package provenance; that result cannot
 authorize a release.
+
+For a localized change, select the scenario and target explicitly:
+
+```powershell
+powershell.exe -ExecutionPolicy Bypass `
+  -File scripts\Test-RadIA.UsageMatrix.ps1 `
+  -Profile targeted `
+  -ScenarioId calculator-history-fidelity `
+  -TargetId delphi13-win32
+```
+
+Use `-PlanOnly` first to inspect cost and combinations without opening Delphi.
+
+The `targeted` profile uses the already installed build and never silently replaces a developer's IDE.
+Explicitly install the intended revision with `build.ps1 -Install` first. The `startup`, `release`, and
+`regression` profiles build and install their own packages per target.
 
 ## Mandatory release gate
 
@@ -76,22 +104,32 @@ powershell.exe -ExecutionPolicy Bypass `
   -File scripts\Test-RadIA.ReleaseUsage.ps1
 ```
 
-This command composes the following gates without options to skip their main requirements:
+Before occupying the machine, add `-PlanOnly` to obtain the aggregate plan without building, installing,
+or opening Delphi.
+
+This command composes the bounded mandatory gate:
 
 1. run the complete RadIA DUnitX suites on Delphi 12 and 13;
-2. run every registered integration and end-to-end scenario applicable to supported targets;
+2. run startup and shutdown smoke tests on all three supported targets;
 3. generate and build every supported template on Delphi 12 and 13;
 4. perform the visual `2 + 3 = 5` operation in the VCL calculator;
    the scenario also proves that a history request records `2 + 3 = 5` in the list and that clearing
    leaves the list empty;
 5. run all five calculator DUnitX tests;
-6. create, open, and immediately navigate a project on all three IDE targets;
-7. explicitly install the current build and run the startup/shutdown matrix on all three targets;
+6. create, open, and immediately navigate a project on representative Delphi 13 Win32;
+7. validate clean installation and upgrade on the representative target;
 8. route real beginner requests for creation, build, tests, and diagnostics, including educational
    fallback and sanitized local counters.
 
-Once a feature enters the matrix, its scenario becomes mandatory in every following release. The
-release runner accepts no filter, exclusion, or partial approval for these groups.
+The `regression` profile still contains every registered scenario exactly once and distributes them
+across compatible targets. Run the full certification with:
+
+```powershell
+powershell.exe -ExecutionPolicy Bypass `
+  -File scripts\Test-RadIA.UsageMatrix.ps1 `
+  -Profile regression `
+  -EvidencePath Output\Validation\UsageMatrix\regression.json
+```
 
 Package and installer provenance is validated afterwards by the packaging gate because those artifacts do not
 exist yet while `Test-RadIA.ReleaseUsage.ps1` runs. Using `-RequirePackageProvenance` before
@@ -121,7 +159,9 @@ preserves partial evidence and blocks publication; retrying a scenario does not 
 failure into a pass.
 
 The `startup` profile proves that the package loaded, the tool contract is valid, shutdown is clean,
-and no orphan process remains. The `release` profile also executes critical IDE-neutral contracts.
+and no orphan process remains. The `release` profile executes critical host contracts and representative
+journeys. `targeted` requires `-ScenarioId`; `regression` prevents registered scenarios from falling out
+of the full certification.
 The first proves explicit intent-route confirmation, command review, chat fallback, and host
 validation of the pending command. DUnitX runs sixteen natural prompts against the real Pascal
 classifier; the host-neutral contract confirms that telemetry cannot accept prompt content. New

--- a/docs/development/usage_test_matrix.md
+++ b/docs/development/usage_test_matrix.md
@@ -1,7 +1,7 @@
 # Matriz automatizada de testes de uso
 
 A matriz de uso valida o RadIA como produto dentro do Delphi, complementando testes unitários e Web.
-Ela é obrigatória para toda release e cobre Delphi 12 Win32, Delphi 13 Win32 e Delphi 13 IDE64.
+Ela possui níveis diferentes para não transformar toda entrega em uma certificação de várias horas.
 
 ## Camadas
 
@@ -52,6 +52,20 @@ powershell.exe -ExecutionPolicy Bypass `
 `-PlanOnly` valida o manifesto e retorna JSON com todas as combinações que seriam executadas. Não
 inicia, instala ou modifica a IDE.
 
+## Níveis de execução
+
+| Nível | Quando usar | Abrangência |
+|---|---|---|
+| `release` | Toda publicação corretiva ou menor | Suítes completas, templates, startup nos três alvos e jornadas críticas no Delphi 13 Win32 |
+| `targeted` | Durante o desenvolvimento e após uma correção localizada | Somente cenários e alvos informados explicitamente |
+| `regression` | Release maior, mudança transversal ou investigação de instabilidade | Todos os 49 fluxos em todos os alvos compatíveis |
+
+Execute obrigatoriamente `regression` quando houver mudança no instalador, lifecycle da WebView2,
+shutdown da IDE, isolamento de sessão, segurança/consentimento, orquestrador E2E ou matriz de targets.
+Também execute antes de uma release maior, após uma falha que não possa ser isolada e quando a seleção
+direcionada não representar com segurança a superfície alterada. A regressão completa é uma certificação
+sob demanda; ela não bloqueia rotineiramente releases menores já cobertas pelo gate `release`.
+
 ## Executar durante o desenvolvimento
 
 Feche todas as instâncias do Delphi e execute:
@@ -63,9 +77,29 @@ powershell.exe -ExecutionPolicy Bypass `
 ```
 
 O resultado agregado fica em `Output/Validation/UsageMatrix/usage-matrix.json`. No perfil `release`, o
-orquestrador agrupa as jornadas por alvo e instala o pacote correspondente antes de executá-las. Durante o
+orquestrador executa as jornadas críticas no Delphi 13 Win32. Durante o
 desenvolvimento, a evidência informa que a origem está suja e que a proveniência do pacote não foi
 exigida; esse resultado não autoriza uma release.
+
+Para executar somente a área alterada, informe cenário e alvo explicitamente:
+
+```powershell
+powershell.exe -ExecutionPolicy Bypass `
+  -File scripts\Test-RadIA.UsageMatrix.ps1 `
+  -Profile targeted `
+  -ScenarioId calculator-history-fidelity `
+  -TargetId delphi13-win32
+```
+
+Use `-PlanOnly` antes da execução para conferir o custo e as combinações sem abrir o Delphi. Exemplos de
+seleção: UI usa `chat-window-state-persistence`; agente usa `agent-step-budget` e
+`request-cancellation-recovery`; geração usa `natural-vcl-project-creation` e
+`calculator-history-fidelity`; testes e reparo usam `build-failure-repair` e
+`dunitx-create-run-repair`.
+
+O perfil `targeted` usa o build já instalado e nunca troca silenciosamente a IDE do desenvolvedor. Instale
+explicitamente a revisão desejada com `build.ps1 -Install` antes de executá-lo. Os perfis `startup`,
+`release` e `regression` geram e instalam seus próprios pacotes por alvo.
 
 ## Gate obrigatório de release
 
@@ -76,22 +110,32 @@ powershell.exe -ExecutionPolicy Bypass `
   -File scripts\Test-RadIA.ReleaseUsage.ps1
 ```
 
-Esse comando compõe, sem opções para pular os gates principais:
+Antes de ocupar a máquina, acrescente `-PlanOnly` para obter o plano agregado sem compilar, instalar ou
+abrir o Delphi.
+
+Esse comando compõe o gate rápido e obrigatório:
 
 1. suítes DUnitX completas do RadIA no Delphi 12 e 13;
-2. todos os cenários registrados de integração e ponta a ponta aplicáveis aos alvos suportados;
+2. smoke de inicialização e encerramento nos três alvos suportados;
 3. geração e build de todos os templates suportados no Delphi 12 e 13;
 4. operação visual `2 + 3 = 5` na calculadora VCL;
    o cenário também comprova que o pedido de histórico gera `2 + 3 = 5` na lista e que a ação de
    limpeza deixa a lista vazia;
 5. execução dos cinco testes DUnitX da calculadora;
-6. criação, abertura e navegação imediata de projeto nos três alvos da IDE;
-7. instalação explícita do build atual e matriz de inicialização/encerramento nos três alvos;
+6. criação, abertura e navegação imediata no Delphi 13 Win32 representativo;
+7. instalação limpa e atualização no alvo representativo;
 8. roteamento real de pedidos iniciantes para criação, build, testes e diagnóstico, com fallback
    educativo e contadores locais sanitizados.
 
-A entrada de uma funcionalidade na matriz torna seu cenário obrigatório nas releases seguintes. O
-runner de release não aceita filtro, exclusão ou aprovação parcial desses grupos.
+O perfil `regression` continua contendo todos os cenários registrados exatamente uma vez e os distribui
+pelos alvos compatíveis. Execute a certificação completa com:
+
+```powershell
+powershell.exe -ExecutionPolicy Bypass `
+  -File scripts\Test-RadIA.UsageMatrix.ps1 `
+  -Profile regression `
+  -EvidencePath Output\Validation\UsageMatrix\regression.json
+```
 
 A proveniência dos packages e do instalador é validada depois, no gate de empacotamento, porque esses
 artefatos ainda não existem durante `Test-RadIA.ReleaseUsage.ps1`. Usar `-RequirePackageProvenance`
@@ -121,7 +165,9 @@ preserva evidência parcial e bloqueia a publicação; repetir um cenário não 
 em sucesso.
 
 O perfil `startup` comprova package carregado, contrato de tools válido, shutdown limpo e ausência de
-processos órfãos. O perfil `release` também executa contratos críticos independentes da IDE. O
+processos órfãos. O perfil `release` executa contratos críticos independentes da IDE e jornadas
+representativas. O perfil `targeted` exige `-ScenarioId`; o perfil `regression` impede que um cenário
+registrado fique fora da certificação completa. O
 primeiro comprova confirmação explícita da rota por intenção, revisão do comando, continuação no chat
 e validação do comando pendente pelo host. A suíte DUnitX executa dezesseis prompts naturais contra
 o classificador Pascal real; o contrato host-neutral confirma que a telemetria não aceita conteúdo

--- a/docs/guides/impact_based_tests.en.md
+++ b/docs/guides/impact_based_tests.en.md
@@ -1,8 +1,8 @@
 # Impact-based DUnitX tests
 
 During development, RadIA can calculate and run the smallest DUnitX fixture set it can safely justify.
-This shortens feedback without weakening the release gate, which still runs every suite, the calculator,
-and project opening scenarios.
+This shortens feedback. The release gate still runs complete suites on both compilers, while localized
+E2E journeys use the usage matrix `targeted` profile.
 
 ## How selection works
 
@@ -24,4 +24,5 @@ fixtures, a coverage report that omits a changed unit, more than 100 filters, or
 files. Files and reports outside the workspace are rejected.
 
 Use impact selection for fast development feedback. Every release still runs the complete Delphi 12 and
-13 suites, calculator functional and DUnitX tests, and project creation, opening, and navigation gates.
+13 suites and the critical E2E set. Use full regression under the conditions documented in
+[Automated usage test matrix](../development/usage_test_matrix.en.md).

--- a/docs/guides/impact_based_tests.md
+++ b/docs/guides/impact_based_tests.md
@@ -1,8 +1,9 @@
 # Testes DUnitX selecionados por impacto
 
 Durante o desenvolvimento, o RadIA pode calcular e executar o menor conjunto de fixtures DUnitX que
-consegue justificar com segurança. Essa seleção reduz o tempo de feedback sem enfraquecer o gate de
-release, que continua executando todas as suítes, a calculadora e a abertura de projetos.
+consegue justificar com segurança. Essa seleção reduz o tempo de feedback. O gate de release continua
+executando as suítes completas nos dois compiladores, enquanto jornadas E2E localizadas usam o perfil
+`targeted` da matriz de uso.
 
 ## Como a seleção funciona
 
@@ -53,5 +54,6 @@ dependências continua sendo responsável pela seleção das fixtures.
 
 Use a seleção por impacto para feedback rápido após mudanças localizadas. Use `RunDUnitXTests` sem
 filtros quando quiser solicitar explicitamente toda a suíte. Em qualquer release, o processo oficial
-ignora otimizações de impacto e executa obrigatoriamente as suítes completas no Delphi 12 e 13, os
-testes funcionais e DUnitX da calculadora e a criação, abertura e navegação de projetos.
+executa as suítes completas no Delphi 12 e 13 e o conjunto E2E crítico. Use a regressão completa nas
+condições documentadas em
+[Matriz automatizada de testes de uso](../development/usage_test_matrix.md).

--- a/docs/reference/intent_routing.en.md
+++ b/docs/reference/intent_routing.en.md
@@ -44,7 +44,7 @@ recommendation.
 The automated matrix exercises sixteen natural Portuguese and English requests across project
 creation, build repair, tests, and diagnostics. Educational or ambiguous questions remain in chat.
 These tests execute the real Pascal classifier in the Delphi 12 and 13 DUnitX suites and belong to
-the indivisible release gate.
+the critical release gate and the complete regression certification.
 
 See [Delphi journeys](../guides/user_guide_journeys.en.md) for available workflows and the
 [security model](tool_security_model.en.md) for protections applied after confirmation.

--- a/docs/reference/intent_routing.md
+++ b/docs/reference/intent_routing.md
@@ -44,7 +44,7 @@ recriado quando houver uma nova recomendação.
 A matriz automatizada exercita dezesseis pedidos naturais em português e inglês para criação de
 projeto, correção de build, testes e diagnóstico. Perguntas educativas ou ambíguas continuam no
 chat. Esses testes usam o classificador Pascal real nas suítes DUnitX de Delphi 12 e 13 e integram o
-gate indivisível de release.
+gate crítico de release e a certificação completa de regressão.
 
 Consulte [Jornadas Delphi](../guides/user_guide_journeys.md) para os fluxos disponíveis e
 [Modelo de segurança](tool_security_model.md) para as proteções aplicadas após a confirmação.

--- a/scripts/Test-RadIA.ReleasePromises.ps1
+++ b/scripts/Test-RadIA.ReleasePromises.ps1
@@ -17,9 +17,11 @@ if ($promises.schemaVersion -ne 1 -or $usage.schemaVersion -ne 1) {
     throw "Unsupported promise or usage matrix schema."
 }
 
-$releaseProfile = @($usage.profiles | Where-Object { $_.id -eq "release" })
-if ($releaseProfile.Count -ne 1) {
-    throw "The release usage profile is missing or duplicated."
+$regressionProfile = @(
+    $usage.profiles | Where-Object { $_.id -eq "regression" }
+)
+if ($regressionProfile.Count -ne 1) {
+    throw "The regression usage profile is missing or duplicated."
 }
 
 $results = @()
@@ -43,8 +45,8 @@ foreach ($promise in $promises.promises) {
         if ($scenario[0].scope -ne "user-journey") {
             $reasons += "scenario-is-not-a-user-journey"
         }
-        if ($promise.scenarioId -notin $releaseProfile[0].scenarioIds) {
-            $reasons += "scenario-not-required-by-release"
+        if ($promise.scenarioId -notin $regressionProfile[0].scenarioIds) {
+            $reasons += "scenario-not-required-by-regression"
         }
         $missingTargets = @(
             $promise.requiredTargets |

--- a/scripts/Test-RadIA.ReleaseUsage.ps1
+++ b/scripts/Test-RadIA.ReleaseUsage.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding()]
 param(
-    [string]$EvidenceRoot = ".\Output\Validation\ReleaseUsage"
+    [string]$EvidenceRoot = ".\Output\Validation\ReleaseUsage",
+    [switch]$PlanOnly
 )
 
 $ErrorActionPreference = "Stop"
@@ -14,6 +15,25 @@ if (-not $resolvedEvidenceRoot.StartsWith(
     [StringComparison]::OrdinalIgnoreCase
 )) {
     throw "Release usage evidence must remain inside Output."
+}
+if ($PlanOnly) {
+    $matrixRunner = Join-Path $PSScriptRoot "Test-RadIA.UsageMatrix.ps1"
+    $startupPlan = & $matrixRunner -Profile "startup" -PlanOnly |
+        ConvertFrom-Json
+    $releasePlan = & $matrixRunner -Profile "release" -PlanOnly |
+        ConvertFrom-Json
+    [PSCustomObject]@{
+        schemaVersion = 1
+        profile = "release-gate"
+        unitTestTargetCount = 2
+        generatedProjectTargetCount = 2
+        startupRunCount = $startupPlan.runCount
+        criticalRunCount = $releasePlan.runCount
+        totalIdeRunCount = $startupPlan.runCount + $releasePlan.runCount
+        startupPlan = $startupPlan
+        criticalPlan = $releasePlan
+    } | ConvertTo-Json -Depth 8
+    exit 0
 }
 $runningIDEs = @(
     Get-Process bds -ErrorAction SilentlyContinue |
@@ -34,44 +54,6 @@ function Stop-RadIAReleaseAuxiliaryProcesses {
                 "$($process.ProcessName):$($process.Id)."
             )
         }
-    }
-}
-
-function Stop-RadIAReleaseIDEProcesses {
-    $processes = @(
-        Get-Process bds -ErrorAction SilentlyContinue |
-            Where-Object { -not $_.HasExited }
-    )
-    foreach ($process in $processes) {
-        Stop-Process -Id $process.Id -Force
-        if (-not $process.WaitForExit(10000)) {
-            throw "Delphi process did not stop after a failed startup probe."
-        }
-    }
-}
-
-function Install-RadIAReleaseTarget {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$DelphiVersion,
-        [switch]$IDE64
-    )
-
-    Stop-RadIAReleaseAuxiliaryProcesses
-    $installArguments = @{
-        DelphiVersion = $DelphiVersion
-        Install = $true
-    }
-    if ($IDE64) {
-        $installArguments.IDE64 = $true
-    }
-    & (Join-Path $repositoryRoot "build.ps1") @installArguments
-    if ($LASTEXITCODE -ne 0) {
-        throw (
-            "The current build could not be installed for Delphi " +
-            "$DelphiVersion " +
-            $(if ($IDE64) { "Win64" } else { "Win32" }) + "."
-        )
     }
 }
 
@@ -134,146 +116,20 @@ foreach ($target in $generatedProjectTargets) {
         Join-Path $resolvedEvidenceRoot "generated-projects-matrix.json"
     )
 
-$installationTargets = @(
-    [PSCustomObject]@{ Version = "23.0"; IDE64 = $false },
-    [PSCustomObject]@{ Version = "37.0"; IDE64 = $false },
-    [PSCustomObject]@{ Version = "37.0"; IDE64 = $true }
-)
-foreach ($target in $installationTargets) {
-    Install-RadIAReleaseTarget `
-        -DelphiVersion $target.Version `
-        -IDE64:$target.IDE64
-}
-
-$openingTargets = @(
-    [PSCustomObject]@{ Id = "delphi12-win32"; Version = "23.0"; IDE64 = $false },
-    [PSCustomObject]@{ Id = "delphi13-win32"; Version = "37.0"; IDE64 = $false },
-    [PSCustomObject]@{ Id = "delphi13-ide64"; Version = "37.0"; IDE64 = $true }
-)
-$openingResults = @()
-$openingEvidencePath = Join-Path `
-    $resolvedEvidenceRoot `
-    "project-opening-matrix.json"
-
-function Test-RadIAReleaseJourneyRetryable {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Output
+& (Join-Path $PSScriptRoot "Test-RadIA.UsageMatrix.ps1") `
+    -Profile "startup" `
+    -EvidencePath (
+        Join-Path $resolvedEvidenceRoot "startup-matrix.json"
     )
-
-    $retryableMessages = @(
-        "Delphi did not become ready for the smoke test.",
-        "The Delphi File menu did not open.",
-        "The Delphi file dialog did not open."
-    )
-    foreach ($message in $retryableMessages) {
-        if ($Output.Contains($message)) {
-            return $true
-        }
-    }
-    return $false
-}
-
-foreach ($target in $openingTargets) {
-    $arguments = @(
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-File",
-        (Join-Path $PSScriptRoot "Test-RadIA.ProjectCreationNavigation.ps1"),
-        "-DelphiVersion",
-        $target.Version
-    )
-    if ($target.IDE64) {
-        $arguments += "-IDE64"
-    }
-    $stopwatch = [Diagnostics.Stopwatch]::StartNew()
-    $previousErrorActionPreference = $ErrorActionPreference
-    try {
-        $ErrorActionPreference = "Continue"
-        $output = & powershell.exe @arguments 2>&1 | Out-String
-        $exitCode = $LASTEXITCODE
-    } finally {
-        $ErrorActionPreference = $previousErrorActionPreference
-    }
-    $attemptCount = 1
-    $startupRetryUsed = $false
-    if (
-        $exitCode -ne 0 -and
-        (Test-RadIAReleaseJourneyRetryable -Output $output)
-    ) {
-        $firstAttemptOutput = $output
-        Stop-RadIAReleaseIDEProcesses
-        Install-RadIAReleaseTarget `
-            -DelphiVersion $target.Version `
-            -IDE64:$target.IDE64
-        try {
-            $ErrorActionPreference = "Continue"
-            $output = & powershell.exe @arguments 2>&1 | Out-String
-            $exitCode = $LASTEXITCODE
-        } finally {
-            $ErrorActionPreference = $previousErrorActionPreference
-        }
-        $attemptCount = 2
-        $startupRetryUsed = $true
-        $output = (
-            "First startup attempt failed and was preserved:`r`n" +
-            $firstAttemptOutput +
-            "`r`nBounded startup retry:`r`n" +
-            $output
-        )
-    }
-    $stopwatch.Stop()
-    $openingResults += [PSCustomObject]@{
-        targetId = $target.Id
-        delphiVersion = $target.Version
-        ideArchitecture = if ($target.IDE64) { "Win64" } else { "Win32" }
-        status = if ($exitCode -eq 0) { "passed" } else { "failed" }
-        exitCode = $exitCode
-        durationMs = $stopwatch.ElapsedMilliseconds
-        attemptCount = $attemptCount
-        startupRetryUsed = $startupRetryUsed
-        outputTail = if ($output.Length -gt 8192) {
-            $output.Substring($output.Length - 8192)
-        } else {
-            $output
-        }
-    }
-    [PSCustomObject]@{
-        schemaVersion = 1
-        evidenceKind = "projectCreationOpeningMatrix"
-        product = "RadIA"
-        status = if (
-            @($openingResults | Where-Object { $_.status -eq "failed" }).Count `
-                -eq 0
-        ) {
-            "passed"
-        } else {
-            "failed"
-        }
-        expectedTargetCount = $openingTargets.Count
-        completedTargetCount = $openingResults.Count
-        generatedAtUtc = [DateTime]::UtcNow.ToString("o")
-        targets = $openingResults
-    } |
-        ConvertTo-Json -Depth 6 |
-        Set-Content `
-            -LiteralPath $openingEvidencePath `
-            -Encoding UTF8
-    if ($exitCode -ne 0) {
-        throw "Project creation and opening failed for $($target.Id)."
-    }
-}
 
 & (Join-Path $PSScriptRoot "Test-RadIA.UsageMatrix.ps1") `
     -Profile "release" `
     -EvidencePath (
-        Join-Path $resolvedEvidenceRoot "automated-usage-matrix.json"
+        Join-Path $resolvedEvidenceRoot "release-critical-matrix.json"
     )
 
 Write-Host (
     "Release usage gate passed: public promises, complete DUnitX, " +
-    "registered integration " +
-    "and end-to-end scenarios, calculator, generated projects, project " +
-    "opening, and automated usage matrix."
+    "generated projects, startup smoke on every supported target, and " +
+    "bounded release-critical journeys on the representative target."
 )

--- a/scripts/Test-RadIA.UsageMatrix.ps1
+++ b/scripts/Test-RadIA.UsageMatrix.ps1
@@ -1,9 +1,11 @@
 [CmdletBinding()]
 param(
-    [ValidateSet("startup", "release")]
+    [ValidateSet("startup", "release", "targeted", "regression")]
     [string]$Profile = "startup",
 
     [string[]]$TargetId = @(),
+
+    [string[]]$ScenarioId = @(),
 
     [string]$EvidencePath = (
         ".\Output\Validation\UsageMatrix\usage-matrix.json"
@@ -92,7 +94,7 @@ $profileDefinition = @(
 if ($profileDefinition.Count -ne 1) {
     throw "Usage profile was not found: $Profile"
 }
-if ($Profile -eq "release") {
+if ($Profile -eq "regression") {
     $registeredScenarioIds = @($manifest.scenarios.id | Sort-Object -Unique)
     $releaseScenarioEntries = @($profileDefinition[0].scenarioIds)
     $releaseScenarioIds = @(
@@ -118,7 +120,7 @@ if ($Profile -eq "release") {
         $duplicateReleaseScenarios.Count -gt 0
     ) {
         throw (
-            "The release profile must contain every registered usage " +
+            "The regression profile must contain every registered usage " +
             "scenario exactly once. Missing: " +
             "$($missingReleaseScenarios -join ', '). Unknown: " +
             "$($unknownReleaseScenarios -join ', '). Duplicated: " +
@@ -126,7 +128,22 @@ if ($Profile -eq "release") {
         )
     }
 }
+if ($Profile -eq "targeted" -and $ScenarioId.Count -eq 0) {
+    throw "The targeted profile requires at least one -ScenarioId."
+}
+$unknownScenarios = @(
+    $ScenarioId | Where-Object { $_ -notin @($manifest.scenarios.id) }
+)
+if ($unknownScenarios.Count -gt 0) {
+    throw "Unknown usage scenario(s): $($unknownScenarios -join ', ')"
+}
 $selectedTargets = @($manifest.targets)
+if ($TargetId.Count -eq 0 -and $profileDefinition[0].targetIds) {
+    $selectedTargets = @(
+        $manifest.targets |
+            Where-Object { $_.id -in @($profileDefinition[0].targetIds) }
+    )
+}
 if ($TargetId.Count -gt 0) {
     $unknownTargets = @(
         $TargetId | Where-Object { $_ -notin @($manifest.targets.id) }
@@ -138,9 +155,13 @@ if ($TargetId.Count -gt 0) {
         $manifest.targets | Where-Object { $_.id -in $TargetId }
     )
 }
+$selectedScenarioIds = @($profileDefinition[0].scenarioIds)
+if ($ScenarioId.Count -gt 0) {
+    $selectedScenarioIds = @($ScenarioId)
+}
 $selectedScenarios = @(
     $manifest.scenarios |
-        Where-Object { $_.id -in $profileDefinition[0].scenarioIds }
+        Where-Object { $_.id -in $selectedScenarioIds }
 )
 if ($selectedTargets.Count -eq 0 -or $selectedScenarios.Count -eq 0) {
     throw "Usage matrix selection is empty."
@@ -151,7 +172,8 @@ $evidenceDirectory = Split-Path -Parent $resolvedEvidencePath
 $planEntries = @()
 foreach ($target in $selectedTargets) {
     foreach ($scenario in @($selectedScenarios | Where-Object {
-        $_.scope -ne "host"
+        $_.scope -ne "host" -and
+        (-not $_.targetIds -or $target.id -in @($_.targetIds))
     })) {
         $targetEvidence = Join-Path `
             $evidenceDirectory `
@@ -217,7 +239,8 @@ $matrixStopwatch = [Diagnostics.Stopwatch]::StartNew()
 $installedTargetId = ""
 foreach ($run in $planEntries) {
     Stop-RadIAUsageAuxiliaryProcesses
-    if ($Profile -eq "release" -and $run.scope -ne "host" -and
+    if ($Profile -in @("startup", "release", "regression") -and
+        $run.scope -ne "host" -and
         $installedTargetId -ne $run.targetId) {
         $installArguments = @{
             DelphiVersion = $run.delphiVersion


### PR DESCRIPTION
## Resumo\n\n- reduz o gate rotineiro de release de 49 para 12 jornadas de IDE\n- preserva os 49 fluxos no perfil egression sob demanda\n- adiciona o perfil 	argeted com seleção explícita de cenário e alvo\n- adiciona -PlanOnly ao gate oficial\n- documenta quando cada nível deve ser usado em português e inglês\n\n## Validação\n\n- ESLint aprovado\n- Web: 208/208\n- contratos focados: 54/54\n- promessas: 13/13 cobertas\n- planos: release 12 jornadas; regressão 49 jornadas\n- nenhuma IDE foi aberta