### PR TITLE
Corrigir conclusão e recuperação da criação de projetos

### DIFF
--- a/RadIA.dproj
+++ b/RadIA.dproj
@@ -65,7 +65,7 @@
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.5.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.5.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.6.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.6.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     </PropertyGroup>
@@ -73,14 +73,14 @@
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.5.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.5.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.6.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.6.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64x)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.5.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.5.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.6.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.6.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <BCC_EnableBatchCompilation>true</BCC_EnableBatchCompilation>
     </PropertyGroup>

--- a/RadIA.rc
+++ b/RadIA.rc
@@ -1,6 +1,6 @@
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,17,5,0
-PRODUCTVERSION 2,17,5,0
+FILEVERSION 2,17,6,0
+PRODUCTVERSION 2,17,6,0
 FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -17,12 +17,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Rad IA Open Source Project\0"
             VALUE "FileDescription", "Rad IA - AI Assistant for Delphi IDE\0"
-            VALUE "FileVersion", "2.17.5.0\0"
+            VALUE "FileVersion", "2.17.6.0\0"
             VALUE "InternalName", "RadIA\0"
             VALUE "LegalCopyright", "Copyright (c) 2026\0"
             VALUE "OriginalFilename", "RadIA.bpl\0"
             VALUE "ProductName", "Rad IA\0"
-            VALUE "ProductVersion", "2.17.5.0\0"
+            VALUE "ProductVersion", "2.17.6.0\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/Source/Core/RadIA.Core.AgentController.pas
+++ b/Source/Core/RadIA.Core.AgentController.pas
@@ -192,6 +192,7 @@ begin
         end;
         SetRuntime(nil);
         LRuntime.Free;
+        TInterlocked.Exchange(FRunning, 0);
         if Assigned(FOnFinished) then
           FOnFinished(LResult);
       finally

--- a/Source/Core/RadIA.Core.AgentProvider.pas
+++ b/Source/Core/RadIA.Core.AgentProvider.pas
@@ -52,6 +52,8 @@ type
     FPromptTokens: Integer;
     FCompletionTokens: Integer;
     function BuildDecisionPrompt(const AContextJson: string): string;
+    function BuildRelevantToolCatalog(const AContextJson: string): string;
+    class function IsProjectCreationTool(const AName: string): Boolean; static;
   public
     constructor Create(
       const AService: IRadIAService;
@@ -76,6 +78,7 @@ implementation
 
 uses
   System.JSON,
+  System.StrUtils,
   System.SyncObjs,
   RadIA.Core.TokenUsage,
   RadIA.Core.Types;
@@ -243,10 +246,75 @@ begin
     'available, run GetCoverageSummary after tests. If build or tests fail, ' +
     'inspect their structured ' +
     'result, prepare the smallest reviewable correction, request consent, ' +
-    'apply it, and repeat. Do not repeat an unchanged patch or tool call.' +
+    'apply it, and repeat. Do not repeat an unchanged patch or tool call. ' +
+    'When GetToolResultRange returns hasMore=false, the requested range is ' +
+    'complete. Do not request that artifact range again; continue with the ' +
+    'next functional validation step.' +
     sLineBreak +
-    'TOOLS:' + sLineBreak + FSettings.ToolCatalogJson + sLineBreak +
+    'TOOLS:' + sLineBreak + BuildRelevantToolCatalog(AContextJson) + sLineBreak +
     'CURRENT_STATE:' + sLineBreak + AContextJson;
+end;
+
+function TRadIAAgentServiceDecisionProvider.BuildRelevantToolCatalog(
+  const AContextJson: string
+): string;
+var
+  LFiltered: TJSONArray;
+  LIndex: Integer;
+  LItem: TJSONObject;
+  LName: string;
+  LSource: TJSONArray;
+  LValue: TJSONValue;
+begin
+  Result := FSettings.ToolCatalogJson;
+  if not AContextJson.Contains(
+    'Create a Delphi project from the user requirements.'
+  ) then
+    Exit;
+  LSource := TJSONObject.ParseJSONValue(
+    FSettings.ToolCatalogJson
+  ) as TJSONArray;
+  if not Assigned(LSource) then
+    Exit;
+  LFiltered := TJSONArray.Create;
+  try
+    for LIndex := 0 to LSource.Count - 1 do
+    begin
+      if not (LSource[LIndex] is TJSONObject) then
+        Continue;
+      LItem := TJSONObject(LSource[LIndex]);
+      LName := LItem.GetValue<string>('name', '');
+      if not IsProjectCreationTool(LName) then
+        Continue;
+      LValue := TJSONObject.ParseJSONValue(LItem.ToJSON);
+      LFiltered.AddElement(LValue);
+    end;
+    if LFiltered.Count > 0 then
+      Result := LFiltered.ToJSON;
+  finally
+    LFiltered.Free;
+    LSource.Free;
+  end;
+end;
+
+class function TRadIAAgentServiceDecisionProvider.IsProjectCreationTool(
+  const AName: string
+): Boolean;
+begin
+  Result := IndexText(AName, [
+    'GetActiveProject', 'GetIDEState', 'GetGitStatus', 'ListOpenFiles',
+    'GetInstallationHealth', 'DiagnoseDelphiDependencies',
+    'GetKnowledgeStatus', 'SearchKnowledge', 'RetrieveKnowledge',
+    'GetKnowledgeDocument', 'PreviewProjectTemplate',
+    'CreateProjectFromTemplate', 'OpenCreatedProject',
+    'ValidateCreatedProject', 'BuildProject', 'GetBuildStatus',
+    'GetCompilerMessages', 'RunDUnitXTests', 'GetCoverageSummary',
+    'StartDebugging', 'StopDebugging', 'GetDebuggerState',
+    'GetRuntimeWindows', 'GetRuntimeControlTree',
+    'PreviewRuntimeScenario', 'RunRuntimeScenario',
+    'GetRuntimeScenarioStatus', 'CancelRuntimeScenario',
+    'GetProjectHealth', 'GetToolResultRange'
+  ]) >= 0;
 end;
 
 procedure TRadIAAgentServiceDecisionProvider.CancelDecision;

--- a/Source/Core/RadIA.Core.AgentRuntime.pas
+++ b/Source/Core/RadIA.Core.AgentRuntime.pas
@@ -141,15 +141,18 @@ type
     FStatus: TRadIAAgentStatus;
     FMessage: string;
     FStepCount: Integer;
+    FRecoveryInput: string;
   public
     constructor Create(
       const AStatus: TRadIAAgentStatus;
       const AMessage: string;
-      const AStepCount: Integer
+      const AStepCount: Integer;
+      const ARecoveryInput: string = ''
     );
     property Status: TRadIAAgentStatus read FStatus;
     property Message: string read FMessage;
     property StepCount: Integer read FStepCount;
+    property RecoveryInput: string read FRecoveryInput;
   end;
 
   IRadIAAgentDecisionProvider = interface
@@ -387,6 +390,10 @@ type
       const ADecision: TRadIAAgentDecision
     ): string;
     function CheckRepeatedCall(
+      const ADecision: TRadIAAgentDecision
+    ): Boolean;
+    function DetectRecoveryInput: string;
+    function TryRecoverCompletedArtifactRangeRepeat(
       const ADecision: TRadIAAgentDecision
     ): Boolean;
     procedure AddToolStep(
@@ -778,12 +785,14 @@ end;
 constructor TRadIAAgentRunResult.Create(
   const AStatus: TRadIAAgentStatus;
   const AMessage: string;
-  const AStepCount: Integer
+  const AStepCount: Integer;
+  const ARecoveryInput: string
 );
 begin
   FStatus := AStatus;
   FMessage := AMessage;
   FStepCount := AStepCount;
+  FRecoveryInput := ARecoveryInput;
 end;
 
 { TRadIAAgentCheckpointSummary }
@@ -1262,7 +1271,8 @@ begin
   LStep.CorrelationId := ACorrelationId;
   LStep.Success := AResult.Success;
   LStep.ResultJson := AResult.ContentJson;
-  if Assigned(FResultStore) and (LStep.ResultJson <> '') then
+  if Assigned(FResultStore) and (LStep.ResultJson <> '') and
+    not SameText(ADecision.ToolName, 'GetToolResultRange') then
   begin
     LArtifact := FResultStore.Store(
       FSessionId,
@@ -1817,6 +1827,7 @@ var
   LMetricsJson: TJSONObject;
   LMetrics: TRadIAAgentCompactionMetrics;
   LProfile: TRadIACompactionProfile;
+  LRecoveryInput: string;
   LRoot: TJSONObject;
   LStepArray: TJSONArray;
 begin
@@ -1832,6 +1843,9 @@ begin
     LRoot.AddPair('objective', FObjective);
     LRoot.AddPair('status', RadIAAgentStatusName(FStatus));
     LRoot.AddPair('message', FMessage);
+    LRecoveryInput := DetectRecoveryInput;
+    if not LRecoveryInput.IsEmpty then
+      LRoot.AddPair('recoveryInput', LRecoveryInput);
     LRoot.AddPair('planApproved', TJSONBool.Create(FPlanApproved));
     if HasValidPlan then
       LRoot.AddPair(
@@ -2191,6 +2205,51 @@ begin
   Result := FRepeatedCallCount <= LAllowedRepeatedCalls;
 end;
 
+function TRadIAAgentRuntime.TryRecoverCompletedArtifactRangeRepeat(
+  const ADecision: TRadIAAgentDecision
+): Boolean;
+var
+  LLastStep: TRadIAAgentStep;
+  LRecoveryResult: TRadIAToolResult;
+  LRoot: TJSONObject;
+begin
+  Result := False;
+  if not SameText(ADecision.ToolName, 'GetToolResultRange') or
+    (FSteps.Count = 0) then
+    Exit;
+  LLastStep := FSteps.Last;
+  if not LLastStep.Success or
+    not SameText(LLastStep.ToolName, ADecision.ToolName) or
+    (BuildCallSignature(ADecision) <> FLastCallSignature) then
+    Exit;
+  LRoot := TJSONObject.ParseJSONValue(LLastStep.ResultJson) as TJSONObject;
+  if not Assigned(LRoot) then
+    Exit;
+  try
+    if LRoot.GetValue<Boolean>('hasMore', True) then
+      Exit;
+  finally
+    LRoot.Free;
+  end;
+  LRecoveryResult := TRadIAToolResult.Failed(
+    'artifact_range_already_complete',
+    'The requested artifact range is already fully available in the ' +
+      'decision context. Do not request it again. Continue with the next ' +
+      'functional validation step.'
+  );
+  AddToolStep(
+    ADecision,
+    TGUID.NewGuid.ToString,
+    LRecoveryResult,
+    ElapsedMilliseconds,
+    0
+  );
+  FRepeatedCallCount := 1;
+  UpdatePeriodicSummary;
+  NotifyAndCheckpoint;
+  Result := True;
+end;
+
 function TRadIAAgentRuntime.CanContinueLoop: Boolean;
 begin
   Result := False;
@@ -2271,8 +2330,32 @@ begin
   Result := TRadIAAgentRunResult.Create(
     FStatus,
     FMessage,
-    FSteps.Count
+    FSteps.Count,
+    DetectRecoveryInput
   );
+end;
+
+function TRadIAAgentRuntime.DetectRecoveryInput: string;
+var
+  LIndex: Integer;
+  LStep: TRadIAAgentStep;
+begin
+  Result := '';
+  if FStatus <> asFailed then
+    Exit;
+  for LIndex := FSteps.Count - 1 downto 0 do
+  begin
+    LStep := FSteps[LIndex];
+    if SameText(LStep.ToolName, 'CreateProjectFromTemplate') and
+      LStep.Success then
+      Exit;
+    if SameText(LStep.ToolName, 'CreateProjectFromTemplate') and
+      (ContainsText(LStep.ErrorMessage, 'directory already exists') or
+       ContainsText(LStep.ErrorMessage, 'destination folder must be empty') or
+       ContainsText(LStep.ErrorMessage, 'destination points to an existing file') or
+       SameText(LStep.ErrorCode, 'target_exists')) then
+      Exit('destination');
+  end;
 end;
 
 procedure TRadIAAgentRuntime.HandleCompletionDecision(
@@ -2351,6 +2434,8 @@ begin
     ChangeStatus(asFailed, 'Agent selected an empty tool name.');
     Exit;
   end;
+  if TryRecoverCompletedArtifactRangeRepeat(ADecision) then
+    Exit(True);
   if not CheckRepeatedCall(ADecision) then
   begin
     ChangeStatus(

--- a/Source/Core/RadIA.Core.Journeys.pas
+++ b/Source/Core/RadIA.Core.Journeys.pas
@@ -94,6 +94,10 @@ type
     class function NormalizeCreateContext(
       const AContext: string
     ): string; static;
+    class function ReplaceCreateDestination(
+      const AContext: string;
+      const ADestination: string
+    ): string; static;
     class function HelpText: string; static;
   end;
 
@@ -229,6 +233,26 @@ begin
       ]
     ) then
     Result := Result + ' feature="operationHistory"';
+end;
+
+class function TRadIAJourneyCatalog.ReplaceCreateDestination(
+  const AContext: string;
+  const ADestination: string
+): string;
+var
+  LDestination: string;
+begin
+  LDestination := ADestination.Trim.Replace('"', '');
+  if LDestination.IsEmpty then
+    Exit(AContext);
+  Result := TRegEx.Replace(
+    AContext,
+    'destination=(?:"[^"]*"|''[^'']*''|[^\s]+)',
+    'destination="' + LDestination + '"',
+    [roIgnoreCase]
+  );
+  if SameText(Result, AContext) then
+    Result := AContext.Trim + ' destination="' + LDestination + '"';
 end;
 
 class function TRadIAJourneyCatalog.TryInferCreateProject(

--- a/Source/Core/RadIA.Core.Journeys.pas
+++ b/Source/Core/RadIA.Core.Journeys.pas
@@ -241,18 +241,30 @@ class function TRadIAJourneyCatalog.ReplaceCreateDestination(
 ): string;
 var
   LDestination: string;
+  LMatch: TMatch;
+  LPreviousDestination: string;
 begin
   LDestination := ADestination.Trim.Replace('"', '');
   if LDestination.IsEmpty then
     Exit(AContext);
-  Result := TRegEx.Replace(
+  LMatch := TRegEx.Match(
     AContext,
     'destination=(?:"[^"]*"|''[^'']*''|[^\s]+)',
-    'destination="' + LDestination + '"',
     [roIgnoreCase]
   );
-  if SameText(Result, AContext) then
-    Result := AContext.Trim + ' destination="' + LDestination + '"';
+  if LMatch.Success then
+  begin
+    LPreviousDestination := LMatch.Value.Substring(
+      Length('destination=')
+    ).Trim(['"', '''']);
+    Result := AContext.Replace(
+      LPreviousDestination,
+      LDestination,
+      [rfReplaceAll, rfIgnoreCase]
+    )
+  end
+  else
+    Result := 'destination="' + LDestination + '" ' + AContext.Trim;
 end;
 
 class function TRadIAJourneyCatalog.TryInferCreateProject(

--- a/Source/Core/RadIA.Core.Journeys.pas
+++ b/Source/Core/RadIA.Core.Journeys.pas
@@ -261,7 +261,7 @@ begin
       LPreviousDestination,
       LDestination,
       [rfReplaceAll, rfIgnoreCase]
-    )
+    );
   end
   else
     Result := 'destination="' + LDestination + '" ' + AContext.Trim;

--- a/Source/Core/RadIA.Core.ResultCompactor.pas
+++ b/Source/Core/RadIA.Core.ResultCompactor.pas
@@ -54,6 +54,7 @@ type
     class procedure CompactBuildMessages(const ARoot: TJSONObject); static;
     class procedure CompactKnowledgeItems(const ARoot: TJSONObject); static;
     class procedure CompactListItems(const ARoot: TJSONObject); static;
+    class procedure CompactRuntimeControls(const ARoot: TJSONObject); static;
     class function CompactLines(const AText: string): string; static;
     class function CompactText(const AText: string): string; static;
     class function ExtractCriticalLines(const AText: string): string; static;
@@ -184,6 +185,8 @@ begin
       SameText(AToolName, 'ListIDEActions') or
       SameText(AToolName, 'ListProjectGroupProjects') then
       CompactListItems(LRoot);
+    if SameText(AToolName, 'GetRuntimeControlTree') then
+      CompactRuntimeControls(LRoot);
     for LFieldName in ['output', 'diff'] do
     begin
       if not IsCompactableField(AToolName, LFieldName) then
@@ -214,6 +217,79 @@ begin
     );
   finally
     LRoot.Free;
+  end;
+end;
+
+class procedure TRadIAResultCompactor.CompactRuntimeControls(
+  const ARoot: TJSONObject
+);
+var
+  LControls: TJSONArray;
+  LHasSemanticPaths: Boolean;
+  LIndex: Integer;
+  LKeptControl: TJSONValue;
+  LNewControls: TJSONArray;
+  LObject: TJSONObject;
+  LOmitted: Integer;
+  LPair: TJSONPair;
+  LParentId: string;
+  LPath: string;
+  LValue: TJSONValue;
+begin
+  LValue := ARoot.GetValue('controls');
+  if not (LValue is TJSONArray) then
+    Exit;
+  LControls := TJSONArray(LValue);
+  LHasSemanticPaths := False;
+  for LIndex := 0 to LControls.Count - 1 do
+  begin
+    if not (LControls[LIndex] is TJSONObject) then
+      Continue;
+    LPath := TJSONObject(LControls[LIndex]).GetValue<string>('path', '');
+    if LPath.Contains('/') then
+    begin
+      LHasSemanticPaths := True;
+      Break;
+    end;
+  end;
+  if not LHasSemanticPaths then
+    Exit;
+  LNewControls := TJSONArray.Create;
+  try
+    LOmitted := 0;
+    for LIndex := 0 to LControls.Count - 1 do
+    begin
+      if not (LControls[LIndex] is TJSONObject) then
+      begin
+        Inc(LOmitted);
+        Continue;
+      end;
+      LObject := TJSONObject(LControls[LIndex]);
+      LPath := LObject.GetValue<string>('path', '');
+      LParentId := LObject.GetValue<string>('parentId', '');
+      if not LPath.Contains('/') and (LParentId <> '') then
+      begin
+        Inc(LOmitted);
+        Continue;
+      end;
+      LKeptControl := TJSONObject.ParseJSONValue(LObject.ToJSON);
+      LNewControls.AddElement(LKeptControl);
+    end;
+    if LOmitted = 0 then
+      Exit;
+    LPair := ARoot.RemovePair('controls');
+    LPair.Free;
+    ARoot.AddPair('controls', LNewControls);
+    LPair := ARoot.RemovePair('count');
+    LPair.Free;
+    ARoot.AddPair(
+      'count',
+      TJSONNumber.Create(LNewControls.Count)
+    );
+    LNewControls := nil;
+    ARoot.AddPair('omittedDuplicateControls', TJSONNumber.Create(LOmitted));
+  finally
+    LNewControls.Free;
   end;
 end;
 

--- a/Source/Core/RadIA.Core.Version.pas
+++ b/Source/Core/RadIA.Core.Version.pas
@@ -3,7 +3,7 @@ unit RadIA.Core.Version;
 interface
 
 const
-  CRadIAVersion = '2.17.5';
+  CRadIAVersion = '2.17.6';
 
 function RadIAVersionedCaption(const ACaption: string): string;
 

--- a/Source/Providers/RadIA.Provider.OpenAI.pas
+++ b/Source/Providers/RadIA.Provider.OpenAI.pas
@@ -42,6 +42,11 @@ type
     function ParseCodexModelLine(const ALine: string): TArray<string>;
     function ParseCodexModelList(const AOutput: string): TArray<string>;
   protected
+    function BuildCodexCommandLine(
+      const ACodexPath: string;
+      const AModel: string;
+      const AThreadId: string
+    ): string;
     function GetCodexExecutablePath: string; virtual;
     function UsesCodexCliTransport: Boolean;
     function GetBaseUrl: string; override;
@@ -76,6 +81,25 @@ constructor TRadIAOpenAIProvider.Create(const AConfig: IRadIAConfig);
 begin
   inherited Create(AConfig);
   FProviderId := 'OpenAI';
+end;
+
+function TRadIAOpenAIProvider.BuildCodexCommandLine(
+  const ACodexPath: string;
+  const AModel: string;
+  const AThreadId: string
+): string;
+begin
+  if AThreadId.IsEmpty then
+    Exit(Format(
+      '"%s" -m %s exec --json --sandbox read-only ' +
+        '--ignore-user-config --skip-git-repo-check -',
+      [ACodexPath, AModel]
+    ));
+  Result := Format(
+    '"%s" -m %s exec --sandbox read-only --ignore-user-config ' +
+      'resume --json --skip-git-repo-check "%s" -',
+    [ACodexPath, AModel, AThreadId]
+  );
 end;
 
 function TRadIAOpenAIProvider.GetBaseUrl: string;
@@ -844,18 +868,11 @@ begin
     Exit;
   end;
 
-  if FThreadId.IsEmpty then
-  begin
-    LCmdLine := Format(
-      '"%s" -m %s exec --json --sandbox read-only --ephemeral --skip-git-repo-check -',
-      [LCodexPath, LActiveModel]);
-  end
-  else
-  begin
-    LCmdLine := Format(
-      '"%s" -m %s exec resume --json --skip-git-repo-check "%s" -',
-      [LCodexPath, LActiveModel, FThreadId]);
-  end;
+  LCmdLine := BuildCodexCommandLine(
+    LCodexPath,
+    LActiveModel,
+    FThreadId
+  );
 
   LPromptToSend := APrompt;
   if FThreadId.IsEmpty then

--- a/Source/UI/RadIA.UI.ChatFrame.pas
+++ b/Source/UI/RadIA.UI.ChatFrame.pas
@@ -334,12 +334,28 @@ begin
   end;
 end;
 
+function AgentStateObjectiveContains(
+  const APrompt: string;
+  const AValue: string
+): Boolean;
+var
+  LState: TJSONObject;
+begin
+  LState := ParseAgentCurrentState(APrompt);
+  try
+    Result := Assigned(LState) and
+      LState.GetValue<string>('objective', '').Contains(AValue);
+  finally
+    LState.Free;
+  end;
+end;
+
 function AgentStateHasFailedTool(
   const APrompt: string;
   const AToolName: string
 ): Boolean;
 var
-  LItem: TJSONValue;
+  LIndex: Integer;
   LState: TJSONObject;
   LSteps: TJSONArray;
   LStep: TJSONObject;
@@ -352,16 +368,46 @@ begin
     LSteps := LState.GetValue<TJSONArray>('steps');
     if not Assigned(LSteps) then
       Exit;
-    for LItem in LSteps do
-      if LItem is TJSONObject then
+    for LIndex := LSteps.Count - 1 downto 0 do
+      if LSteps.Items[LIndex] is TJSONObject then
       begin
-        LStep := TJSONObject(LItem);
+        LStep := TJSONObject(LSteps.Items[LIndex]);
         if SameText(LStep.GetValue<string>('toolName', ''), AToolName) and
           not LStep.GetValue<Boolean>('success', True) then
           Exit(True);
       end;
   finally
     LState.Free;
+  end;
+end;
+
+function AgentStateHasSuccessfulToolDestination(
+  const APrompt: string;
+  const AToolName: string;
+  const ADestination: string
+): Boolean;
+var
+  LArguments: TJSONObject;
+  LStep: TJSONObject;
+begin
+  Result := False;
+  LStep := FindSuccessfulAgentToolStep(APrompt, AToolName);
+  if not Assigned(LStep) then
+    Exit;
+  try
+    LArguments := TJSONObject.ParseJSONValue(
+      LStep.GetValue<string>('arguments', '')
+    ) as TJSONObject;
+    try
+      Result := Assigned(LArguments) and SameText(
+        LArguments.GetValue<string>('destinationPath', ''),
+        ADestination
+      );
+    finally
+      LArguments.Free;
+    end;
+  finally
+    LStep.Free;
   end;
 end;
 
@@ -451,6 +497,8 @@ function TRadIAConversationSmokeService.TrySendNaturalVclPrompt(
 ): Boolean;
 var
   LDestination: string;
+  LPreviewReady: Boolean;
+  LRecoveryRun: Boolean;
   LRetryDestination: string;
 begin
   Result :=
@@ -465,8 +513,21 @@ begin
     'RADIA_IDE_SMOKE_NATURAL_VCL_RETRY_DESTINATION'
   );
   if not LRetryDestination.IsEmpty and
-    APrompt.Contains(LRetryDestination) then
+    AgentStateObjectiveContains(APrompt, LRetryDestination) then
     LDestination := LRetryDestination;
+  LRecoveryRun := SameText(LDestination, LRetryDestination) and
+    not LRetryDestination.IsEmpty;
+  if LRecoveryRun then
+    LPreviewReady := AgentStateHasSuccessfulToolDestination(
+      APrompt,
+      'PreviewProjectTemplate',
+      LRetryDestination
+    )
+  else
+    LPreviewReady := AgentStateHasSuccessfulTool(
+      APrompt,
+      'PreviewProjectTemplate'
+    );
   if not AgentStatePlanApproved(APrompt) then
     ACallback(
         '{"kind":"plan","message":"Create and validate the VCL project.",' +
@@ -476,10 +537,7 @@ begin
         False,
         TTokenUsage.Empty
       )
-    else if not AgentStateHasSuccessfulTool(
-      APrompt,
-      'PreviewProjectTemplate'
-    ) then
+    else if not LPreviewReady then
       ACallback(
         '{"kind":"tool","tool":"PreviewProjectTemplate","arguments":{' +
         '"projectName":"RadIAUserCalculator","template":"vcl",' +
@@ -499,7 +557,7 @@ begin
     else if AgentStateHasFailedTool(
       APrompt,
       'CreateProjectFromTemplate'
-    ) then
+    ) and not LRecoveryRun then
       ACallback(
         '{"kind":"fail","message":"Choose another destination."}',
         '',

--- a/Source/UI/RadIA.UI.ChatFrame.pas
+++ b/Source/UI/RadIA.UI.ChatFrame.pas
@@ -334,6 +334,37 @@ begin
   end;
 end;
 
+function AgentStateHasFailedTool(
+  const APrompt: string;
+  const AToolName: string
+): Boolean;
+var
+  LItem: TJSONValue;
+  LState: TJSONObject;
+  LSteps: TJSONArray;
+  LStep: TJSONObject;
+begin
+  Result := False;
+  LState := ParseAgentCurrentState(APrompt);
+  if not Assigned(LState) then
+    Exit;
+  try
+    LSteps := LState.GetValue<TJSONArray>('steps');
+    if not Assigned(LSteps) then
+      Exit;
+    for LItem in LSteps do
+      if LItem is TJSONObject then
+      begin
+        LStep := TJSONObject(LItem);
+        if SameText(LStep.GetValue<string>('toolName', ''), AToolName) and
+          not LStep.GetValue<Boolean>('success', True) then
+          Exit(True);
+      end;
+  finally
+    LState.Free;
+  end;
+end;
+
 function AgentToolResultString(
   const APrompt: string;
   const AToolName: string;
@@ -418,12 +449,24 @@ function TRadIAConversationSmokeService.TrySendNaturalVclPrompt(
   const APrompt: string;
   const ACallback: TCompletionCallback
 ): Boolean;
+var
+  LDestination: string;
+  LRetryDestination: string;
 begin
   Result :=
     (Trim(GetEnvironmentVariable('RADIA_IDE_SMOKE_NATURAL_VCL')) <> '') and
     APrompt.Contains('CURRENT_STATE:');
   if not Result then
     Exit;
+  LDestination := GetEnvironmentVariable(
+    'RADIA_IDE_SMOKE_NATURAL_VCL_DESTINATION'
+  );
+  LRetryDestination := GetEnvironmentVariable(
+    'RADIA_IDE_SMOKE_NATURAL_VCL_RETRY_DESTINATION'
+  );
+  if not LRetryDestination.IsEmpty and
+    APrompt.Contains(LRetryDestination) then
+    LDestination := LRetryDestination;
   if not AgentStatePlanApproved(APrompt) then
     ACallback(
         '{"kind":"plan","message":"Create and validate the VCL project.",' +
@@ -444,12 +487,21 @@ begin
           'RADIA_IDE_SMOKE_DELPHI_VERSION'
         )) + ',"platforms":[' + JsonQuoted(GetEnvironmentVariable(
           'RADIA_IDE_SMOKE_TARGET_PLATFORM'
-        )) + '],"destinationPath":' + JsonQuoted(GetEnvironmentVariable(
-          'RADIA_IDE_SMOKE_NATURAL_VCL_DESTINATION'
-        )) + ',"authorizedRoot":' + JsonQuoted(GetEnvironmentVariable(
+        )) + '],"destinationPath":' + JsonQuoted(LDestination) +
+        ',"authorizedRoot":' + JsonQuoted(GetEnvironmentVariable(
           'RADIA_IDE_SMOKE_NATURAL_VCL_ROOT'
         )) + ',"projectSpecification":{"schemaVersion":1,' +
         '"kind":"calculator","creationProfile":"essential"}}}',
+        '',
+        False,
+        TTokenUsage.Empty
+      )
+    else if AgentStateHasFailedTool(
+      APrompt,
+      'CreateProjectFromTemplate'
+    ) then
+      ACallback(
+        '{"kind":"fail","message":"Choose another destination."}',
         '',
         False,
         TTokenUsage.Empty
@@ -1769,6 +1821,9 @@ begin
       LRoot.GetValue<Boolean>('projectOpened', False) and
       LRoot.GetValue<Boolean>('buildPassed', False) and
       LRoot.GetValue<Boolean>('applicationStarted', False) and
+      LRoot.GetValue<Boolean>('destinationRecovered', False) and
+      LRoot.GetValue<Boolean>('requirementsPreserved', False) and
+      LRoot.GetValue<Boolean>('nativeOrchestration', False) and
       not LRoot.GetValue<Boolean>('cliCompletedEarly', True) and
       not LRoot.GetValue<Boolean>('toolUnavailable', True);
     LEvidence := TJSONObject.Create;
@@ -1805,6 +1860,18 @@ begin
         TJSONBool.Create(LRoot.GetValue<Boolean>('applicationStarted', False))
       );
       LEvidence.AddPair(
+        'destinationRecovered',
+        TJSONBool.Create(LRoot.GetValue<Boolean>('destinationRecovered', False))
+      );
+      LEvidence.AddPair(
+        'requirementsPreserved',
+        TJSONBool.Create(LRoot.GetValue<Boolean>('requirementsPreserved', False))
+      );
+      LEvidence.AddPair(
+        'nativeOrchestration',
+        TJSONBool.Create(LRoot.GetValue<Boolean>('nativeOrchestration', False))
+      );
+      LEvidence.AddPair(
         'cliCompletedEarly',
         TJSONBool.Create(LRoot.GetValue<Boolean>('cliCompletedEarly', True))
       );
@@ -1837,6 +1904,8 @@ var
   LDestination: string;
   LPrompt: string;
   LPromptJson: TJSONString;
+  LRetryDestination: string;
+  LRetryJson: TJSONString;
 begin
   if (FNaturalVclSmokeEvidencePath = '') or not Assigned(FEdgeBrowser) then
     Exit;
@@ -1849,15 +1918,21 @@ begin
   LDestination := GetEnvironmentVariable(
     'RADIA_IDE_SMOKE_NATURAL_VCL_DESTINATION'
   );
+  LRetryDestination := GetEnvironmentVariable(
+    'RADIA_IDE_SMOKE_NATURAL_VCL_RETRY_DESTINATION'
+  );
   LPrompt :=
     'Crie uma calculadora em VCL que exiba também o histórico das operações ' +
     'matemáticas realizadas. Grave em ' + LDestination;
   LPromptJson := TJSONString.Create(LPrompt);
+  LRetryJson := TJSONString.Create(LRetryDestination);
   try
     FEdgeBrowser.ExecuteScript(
-      'beginNaturalVclSmoke(' + LPromptJson.ToJSON + ', 300000);'
+      'beginNaturalVclSmoke(' + LPromptJson.ToJSON + ', ' +
+        LRetryJson.ToJSON + ', 300000);'
     );
   finally
+    LRetryJson.Free;
     LPromptJson.Free;
   end;
 end;

--- a/Source/UI/RadIA.UI.ChatFrame.pas
+++ b/Source/UI/RadIA.UI.ChatFrame.pas
@@ -369,9 +369,9 @@ begin
     if not Assigned(LSteps) then
       Exit;
     for LIndex := LSteps.Count - 1 downto 0 do
-      if LSteps.Items[LIndex] is TJSONObject then
+      if LSteps[LIndex] is TJSONObject then
       begin
-        LStep := TJSONObject(LSteps.Items[LIndex]);
+        LStep := TJSONObject(LSteps[LIndex]);
         if SameText(LStep.GetValue<string>('toolName', ''), AToolName) and
           not LStep.GetValue<Boolean>('success', True) then
           Exit(True);
@@ -379,6 +379,27 @@ begin
   finally
     LState.Free;
   end;
+end;
+
+function AgentStateHasSuccessfulToolDestination(
+  const APrompt: string;
+  const AToolName: string;
+  const ADestination: string
+): Boolean; forward;
+
+function NaturalVclPreviewReady(
+  const APrompt: string;
+  const ARetryDestination: string;
+  const ARecoveryRun: Boolean
+): Boolean;
+begin
+  if ARecoveryRun then
+    Exit(AgentStateHasSuccessfulToolDestination(
+      APrompt,
+      'PreviewProjectTemplate',
+      ARetryDestination
+    ));
+  Result := AgentStateHasSuccessfulTool(APrompt, 'PreviewProjectTemplate');
 end;
 
 function AgentStateHasSuccessfulToolDestination(
@@ -517,17 +538,11 @@ begin
     LDestination := LRetryDestination;
   LRecoveryRun := SameText(LDestination, LRetryDestination) and
     not LRetryDestination.IsEmpty;
-  if LRecoveryRun then
-    LPreviewReady := AgentStateHasSuccessfulToolDestination(
-      APrompt,
-      'PreviewProjectTemplate',
-      LRetryDestination
-    )
-  else
-    LPreviewReady := AgentStateHasSuccessfulTool(
-      APrompt,
-      'PreviewProjectTemplate'
-    );
+  LPreviewReady := NaturalVclPreviewReady(
+    APrompt,
+    LRetryDestination,
+    LRecoveryRun
+  );
   if not AgentStatePlanApproved(APrompt) then
     ACallback(
         '{"kind":"plan","message":"Create and validate the VCL project.",' +

--- a/Source/UI/RadIA.UI.ChatPresenter.pas
+++ b/Source/UI/RadIA.UI.ChatPresenter.pas
@@ -3917,7 +3917,7 @@ begin
     FActiveJourneyContext := LContext;
     FActiveJourneyDefinition := LDefinition;
     FActiveJourneyNative := True;
-    LObjective := LDefinition.BuildAgentObjective(LContext)
+    LObjective := LDefinition.BuildAgentObjective(LContext);
   end
   else
   begin

--- a/Source/UI/RadIA.UI.ChatPresenter.pas
+++ b/Source/UI/RadIA.UI.ChatPresenter.pas
@@ -3913,7 +3913,12 @@ begin
   if not FAgentModeEnabled then
     SetAgentModeEnabled(True);
   if LIsNativeJourney then
+  begin
+    FActiveJourneyContext := LContext;
+    FActiveJourneyDefinition := LDefinition;
+    FActiveJourneyNative := True;
     LObjective := LDefinition.BuildAgentObjective(LContext)
+  end
   else
   begin
     LObjective := LDeclarative.Prompt + sLineBreak + sLineBreak +
@@ -4471,6 +4476,10 @@ var
   LUserMessage: IRadIAChatMessage;
 begin
   LEffectiveSettings := ResolveEffectiveExecutionSettings;
+  FNativeOrchestrationOverride := RequiresNativeCreationOrchestration(
+    AObjective,
+    LEffectiveSettings.Values.ExecutorId
+  );
   if TryStartExternalAgentRun(AObjective, LEffectiveSettings) then
     Exit;
   if not Assigned(FToolExecutor) or not Assigned(FToolRegistry) then
@@ -4484,11 +4493,6 @@ begin
   end;
   if not CheckQuotaAvailability then
     Exit;
-
-  FNativeOrchestrationOverride := RequiresNativeCreationOrchestration(
-    AObjective,
-    LEffectiveSettings.Values.ExecutorId
-  );
 
   LActiveProvider := LEffectiveSettings.Values.ProviderId;
   LActiveModel := LEffectiveSettings.Values.ModelId;

--- a/Source/UI/RadIA.UI.ChatPresenter.pas
+++ b/Source/UI/RadIA.UI.ChatPresenter.pas
@@ -97,6 +97,7 @@ type
     FAgentModeEnabled: Boolean;
     FAgentController: IRadIAAgentRunController;
     FAgentExecutorSettings: TRadIAAgentExecutorSettingsStore;
+    FNativeOrchestrationOverride: Boolean;
     FCliProcessSession: IRadIACliProcessSession;
     FPendingJourneyActive: Boolean;
     FPendingJourneyContext: string;
@@ -104,6 +105,9 @@ type
     FPendingJourneyDefinition: TRadIAJourneyDefinition;
     FPendingJourneyField: string;
     FPendingJourneyNative: Boolean;
+    FActiveJourneyContext: string;
+    FActiveJourneyDefinition: TRadIAJourneyDefinition;
+    FActiveJourneyNative: Boolean;
     FPendingIntentActive: Boolean;
     FPendingIntentCommand: string;
     FPendingIntentConfidence: string;
@@ -251,6 +255,10 @@ type
       out AProviderSettings: TRadIAAgentProviderSettings;
       out ALimits: TRadIAAgentLimits
     );
+    function RequiresNativeCreationOrchestration(
+      const AObjective: string;
+      const AExecutorId: string
+    ): Boolean;
     procedure StartAgentRun(const AObjective: string);
     function TryStartExternalAgentRun(
       const AObjective: string;
@@ -3716,6 +3724,9 @@ procedure TRadIAChatPresenter.StartPendingJourney;
 var
   LObjective: string;
 begin
+  FActiveJourneyContext := FPendingJourneyContext;
+  FActiveJourneyDefinition := FPendingJourneyDefinition;
+  FActiveJourneyNative := FPendingJourneyNative;
   if FPendingJourneyNative then
     LObjective := FPendingJourneyDefinition.BuildAgentObjective(
       FPendingJourneyContext
@@ -3760,6 +3771,13 @@ begin
   PostToWebView('add_message', 'user', APromptText);
   if FPendingJourneyField = 'goal' then
     FPendingJourneyContext := LAnswer
+  else if SameText(FPendingJourneyField, 'destination') and
+    FPendingJourneyNative and
+    SameText(FPendingJourneyDefinition.Command, '/journey create') then
+    FPendingJourneyContext := TRadIAJourneyCatalog.ReplaceCreateDestination(
+      FPendingJourneyContext,
+      LAnswer
+    )
   else
   begin
     if not FPendingJourneyContext.IsEmpty then
@@ -4196,6 +4214,29 @@ begin
       begin
         if not LGuard.IsAlive then
           Exit;
+        if (AResult.Status = asFailed) and
+          SameText(AResult.RecoveryInput, 'destination') and
+          FActiveJourneyNative and
+          SameText(FActiveJourneyDefinition.Command, '/journey create') then
+        begin
+          FPendingJourneyActive := True;
+          FPendingJourneyContext := FActiveJourneyContext;
+          FPendingJourneyDefinition := FActiveJourneyDefinition;
+          FPendingJourneyField := 'destination';
+          FPendingJourneyNative := True;
+          PostToWebView(
+            'journey_input_requested',
+            '',
+            'destination'
+          );
+        end;
+        if AResult.Status in [asCompleted, asCancelled, asFailed] then
+        begin
+          FActiveJourneyContext := '';
+          FActiveJourneyDefinition := Default(TRadIAJourneyDefinition);
+          FActiveJourneyNative := False;
+          FNativeOrchestrationOverride := False;
+        end;
         FRequestInProgress := False;
         if Assigned(FJourneyContext) then
           FJourneyContext.CompleteActivity;
@@ -4217,6 +4258,7 @@ begin
             AProvider,
             AModel
           );
+        PostExecutionRouteToWeb;
       end
     )
   );
@@ -4396,6 +4438,16 @@ begin
   end;
 end;
 
+function TRadIAChatPresenter.RequiresNativeCreationOrchestration(
+  const AObjective: string;
+  const AExecutorId: string
+): Boolean;
+begin
+  Result := AObjective.Contains(
+    'Create a Delphi project from the user requirements.'
+  ) and not SameText(AExecutorId, 'native');
+end;
+
 procedure TRadIAChatPresenter.StartAgentRun(
   const AObjective: string
 );
@@ -4432,6 +4484,11 @@ begin
   end;
   if not CheckQuotaAvailability then
     Exit;
+
+  FNativeOrchestrationOverride := RequiresNativeCreationOrchestration(
+    AObjective,
+    LEffectiveSettings.Values.ExecutorId
+  );
 
   LActiveProvider := LEffectiveSettings.Values.ProviderId;
   LActiveModel := LEffectiveSettings.Values.ModelId;
@@ -4503,6 +4560,7 @@ begin
     LActiveModel
   );
   FHistory := FHistory + [LUserMessage];
+  PostExecutionRouteToWeb;
   SaveChatHistory;
   FRequestInProgress := True;
   if Assigned(FJourneyContext) then
@@ -5226,7 +5284,8 @@ begin
   LEffective := ResolveEffectiveExecutionSettings;
   LProvider := LEffective.Values.ProviderId;
   LAuthType := FConfig.GetProviderAuthType(LProvider);
-  if SameText(LEffective.Values.ExecutorId, 'native') then
+  if FNativeOrchestrationOverride or
+    SameText(LEffective.Values.ExecutorId, 'native') then
     LSettings := TRadIAAgentExecutorSettings.Create(aekNative, '')
   else
     LSettings := TRadIAAgentExecutorSettings.Create(

--- a/Source/UI/Web/chat.css
+++ b/Source/UI/Web/chat.css
@@ -3687,6 +3687,11 @@ body.light-theme .agent-step-git-diff .is-removal {
   opacity: 0.55;
 }
 
+.intent-recommendation-status {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
 @media (max-width: 620px) {
   .intent-recommendation-card {
     margin: 10px 12px;

--- a/Source/UI/Web/chat.js
+++ b/Source/UI/Web/chat.js
@@ -944,8 +944,9 @@ function renderAgentPlanItems(planElement, plan) {
   planElement.replaceChildren();
   plan.forEach(planStep => {
     const item = document.createElement('li');
-    const title = planStep?.title || 'Planned step';
-    const description = planStep?.description || '';
+    const stringStep = typeof planStep === 'string' ? planStep.trim() : '';
+    const title = stringStep || planStep?.title || 'Planned step';
+    const description = stringStep ? '' : (planStep?.description || '');
     item.textContent = description ? `${title} — ${description}` : title;
     planElement.appendChild(item);
   });
@@ -1303,6 +1304,9 @@ function formatToolPayload(payload) {
 function updateExecutionRoute(route) {
   if (!executionRoute || !route) return;
   activeExecutionRoute = { ...activeExecutionRoute, ...route };
+  if (naturalVclSmoke && route.orchestrator === 'radia-native') {
+    naturalVclSmoke.nativeOrchestrationObserved = true;
+  }
   executionRoute.textContent = `Effective: ${route.label || 'Chat | Native provider'}`;
   executionRoute.title = route.details || route.label || 'Effective execution route';
   executionRoute.dataset.mode = route.mode || 'chat';
@@ -1335,9 +1339,17 @@ function createIntentRecommendationButton(label, action, primary = false) {
   button.addEventListener('click', () => {
     postMessageToDelphi({ action });
     if (action !== 'review_intent_recommendation') {
-      button.closest('.intent-recommendation-card')
-        ?.querySelectorAll('button')
+      const card = button.closest('.intent-recommendation-card');
+      card?.querySelectorAll('button')
         .forEach(item => { item.disabled = true; });
+      card?.classList.add('intent-recommendation-resolved');
+      const status = document.createElement('span');
+      status.className = 'intent-recommendation-status';
+      status.textContent = action === 'accept_intent_recommendation'
+        ? 'Starting recommended route…'
+        : 'Continuing as chat…';
+      card?.querySelector('.intent-recommendation-controls')
+        ?.replaceChildren(status);
     }
   });
   return button;
@@ -3309,6 +3321,10 @@ function finishNaturalVclSmoke(status, reason = '', state = {}) {
     projectOpened: succeeded('OpenCreatedProject'),
     buildPassed: succeeded('BuildProject'),
     applicationStarted: succeeded('StartDebugging'),
+    destinationRecovered: naturalVclSmoke.destinationRetried,
+    requirementsPreserved:
+      String(state.objective || '').includes('operationHistory'),
+    nativeOrchestration: naturalVclSmoke.nativeOrchestrationObserved,
     cliCompletedEarly:
       bodyText.includes('CLI task completed.') &&
       !succeeded('CreateProjectFromTemplate'),
@@ -3323,9 +3339,32 @@ function finishNaturalVclSmoke(status, reason = '', state = {}) {
   naturalVclSmoke = null;
 }
 
+function trySubmitNaturalVclRecovery() {
+  if (!naturalVclSmoke || naturalVclSmoke.destinationRetried ||
+      !naturalVclSmoke.recoveryStateObserved ||
+      !naturalVclSmoke.recoveryRequestReady ||
+      !naturalVclSmoke.retryDestination) return;
+  naturalVclSmoke.destinationRetried = true;
+  naturalVclSmoke.recoveryPending = true;
+  naturalVclSmoke.planApproved = false;
+  setPromptText(naturalVclSmoke.retryDestination);
+  submitPrompt(naturalVclSmoke.retryDestination);
+}
+
+function handleJourneyInputRequested(data) {
+  if (!naturalVclSmoke || data.text !== 'destination') return;
+  naturalVclSmoke.recoveryRequestReady = true;
+  trySubmitNaturalVclRecovery();
+}
+
 function continueNaturalVclSmoke(card, state) {
   if (!naturalVclSmoke) return;
   const status = state.status || '';
+  const retryObjectiveActive = naturalVclSmoke.retryDestination &&
+    String(state.objective || '').includes(naturalVclSmoke.retryDestination);
+  if (retryObjectiveActive) {
+    naturalVclSmoke.recoveryPending = false;
+  }
   if (status === 'awaitingApproval' && !naturalVclSmoke.planApproved) {
     const approveButton = [...card.querySelectorAll('.agent-control-button')]
       .find(button => button.textContent === 'Approve plan');
@@ -3348,6 +3387,12 @@ function continueNaturalVclSmoke(card, state) {
     ));
     finishNaturalVclSmoke(complete ? 'passed' : 'failed',
       complete ? '' : 'completed-before-required-evidence', state);
+  } else if (status === 'failed' && state.recoveryInput === 'destination' &&
+      !naturalVclSmoke.destinationRetried) {
+    naturalVclSmoke.recoveryStateObserved = true;
+    trySubmitNaturalVclRecovery();
+  } else if (status === 'failed' && naturalVclSmoke.recoveryPending) {
+    return;
   } else if (status === 'failed' || status === 'cancelled') {
     finishNaturalVclSmoke('failed', `agent-${status}`, state);
   }
@@ -3355,12 +3400,19 @@ function continueNaturalVclSmoke(card, state) {
 
 globalThis.beginNaturalVclSmoke = function beginNaturalVclSmoke(
   prompt,
+  retryDestination = '',
   timeoutMilliseconds = 300000
 ) {
   if (naturalVclSmoke) return;
   naturalVclSmoke = {
     recommendationAccepted: false,
+    destinationRetried: false,
+    nativeOrchestrationObserved: false,
     planApproved: false,
+    recoveryPending: false,
+    recoveryRequestReady: false,
+    recoveryStateObserved: false,
+    retryDestination: String(retryDestination),
     startedAt: globalThis.performance.now(),
     timeoutId: setTimeout(
       () => finishNaturalVclSmoke('failed', 'timeout'),
@@ -3377,7 +3429,14 @@ globalThis.resumeNaturalVclSmoke = function resumeNaturalVclSmoke(
   if (naturalVclSmoke) return;
   naturalVclSmoke = {
     recommendationAccepted: true,
+    destinationRetried: true,
+    nativeOrchestrationObserved:
+      activeExecutionRoute.orchestrator === 'radia-native',
     planApproved: true,
+    recoveryPending: false,
+    recoveryRequestReady: true,
+    recoveryStateObserved: true,
+    retryDestination: '',
     startedAt: globalThis.performance.now(),
     timeoutId: setTimeout(
       () => finishNaturalVclSmoke('failed', 'timeout-after-navigation'),
@@ -5122,6 +5181,7 @@ if (globalThis.chrome?.webview) {
       case 'chat_preflight':        renderChatPreflight(data);                                   break;
       case 'agent_mode_changed':    setAgentMode(data.enabled);                                  break;
       case 'execution_route':       updateExecutionRoute(data);                                  break;
+      case 'journey_input_requested': handleJourneyInputRequested(data);                          break;
       case 'execution_scope':       updateExecutionScope(data);                                  break;
       case 'agent_state':           renderAgentState(data);                                      break;
       case 'agent_history':         renderAgentHistory(data);                                    break;

--- a/Source/UI/Web/chat.js
+++ b/Source/UI/Web/chat.js
@@ -3354,18 +3354,39 @@ function trySubmitNaturalVclRecovery() {
 function handleJourneyInputRequested(data) {
   if (!naturalVclSmoke || data.text !== 'destination') return;
   naturalVclSmoke.recoveryRequestReady = true;
+}
+
+function handleNaturalVclRecoveryMessage(data) {
+  if (!naturalVclSmoke || data.role !== 'assistant' ||
+      !naturalVclSmoke.recoveryStateObserved ||
+      naturalVclSmoke.destinationRetried) return;
+  naturalVclSmoke.recoveryRequestReady = true;
   trySubmitNaturalVclRecovery();
 }
 
 function continueNaturalVclSmoke(card, state) {
   if (!naturalVclSmoke) return;
   const status = state.status || '';
+  const stateSteps = Array.isArray(state.steps) ? state.steps : [];
   const retryObjectiveActive = naturalVclSmoke.retryDestination &&
     String(state.objective || '').includes(naturalVclSmoke.retryDestination);
+  const retryPreviewActive = stateSteps.some(step =>
+    step.toolName === 'PreviewProjectTemplate' && step.success === true &&
+    String(step.arguments || '').includes(naturalVclSmoke.retryDestination)
+  );
   if (retryObjectiveActive) {
     naturalVclSmoke.recoveryPending = false;
   }
+  if (naturalVclSmoke.destinationRetried &&
+      (!retryObjectiveActive || !retryPreviewActive) &&
+      (status === 'failed' || status === 'cancelled')) {
+    return;
+  }
   if (status === 'awaitingApproval' && !naturalVclSmoke.planApproved) {
+    if (requestInProgress) {
+      naturalVclSmoke.pendingApproval = { card, state };
+      return;
+    }
     const approveButton = [...card.querySelectorAll('.agent-control-button')]
       .find(button => button.textContent === 'Approve plan');
     if (!approveButton || approveButton.disabled) return;
@@ -3374,7 +3395,7 @@ function continueNaturalVclSmoke(card, state) {
     return;
   }
   if (status === 'completed') {
-    const steps = Array.isArray(state.steps) ? state.steps : [];
+    const steps = stateSteps;
     const required = [
       'PreviewProjectTemplate',
       'CreateProjectFromTemplate',
@@ -3409,6 +3430,7 @@ globalThis.beginNaturalVclSmoke = function beginNaturalVclSmoke(
     destinationRetried: false,
     nativeOrchestrationObserved: false,
     planApproved: false,
+    pendingApproval: null,
     recoveryPending: false,
     recoveryRequestReady: false,
     recoveryStateObserved: false,
@@ -3433,6 +3455,7 @@ globalThis.resumeNaturalVclSmoke = function resumeNaturalVclSmoke(
     nativeOrchestrationObserved:
       activeExecutionRoute.orchestrator === 'radia-native',
     planApproved: true,
+    pendingApproval: null,
     recoveryPending: false,
     recoveryRequestReady: true,
     recoveryStateObserved: true,
@@ -4845,6 +4868,15 @@ function setRequestState(inProgress) {
     providerDropdownTrigger.setAttribute('aria-disabled', 'false');
     btnQueuePrompt.classList.add('hidden');
     promptTextarea.placeholder = 'Ask Rad IA or type / for commands...';
+    if (naturalVclSmoke?.recoveryStateObserved &&
+        naturalVclSmoke.recoveryRequestReady) {
+      trySubmitNaturalVclRecovery();
+    }
+    if (naturalVclSmoke?.pendingApproval) {
+      naturalVclSmoke.pendingApproval = null;
+      naturalVclSmoke.planApproved = true;
+      postMessageToDelphi({ action: 'approve_agent' });
+    }
   }
   applyModelSelectionState();
   executionRouteSelector.disabled = inProgress;
@@ -5159,7 +5191,10 @@ if (globalThis.chrome?.webview) {
     const data = event.data;
     console.log('[DEBUG] Received message from Delphi:', data.action || 'unknown');
     switch (data.action) {
-      case 'add_message':           addMessage(data.role, data.text, data.provider, data.model); break;
+      case 'add_message':
+        addMessage(data.role, data.text, data.provider, data.model);
+        handleNaturalVclRecoveryMessage(data);
+        break;
       case 'update_message':        updateMessage(data.text, data.isDone, data.provider, data.model); break;
       case 'clear_chat':            clearChat();                                                 break;
       case 'set_theme':             setTheme(data);                                              break;

--- a/Source/UI/Web/chat.js
+++ b/Source/UI/Web/chat.js
@@ -3364,6 +3364,49 @@ function handleNaturalVclRecoveryMessage(data) {
   trySubmitNaturalVclRecovery();
 }
 
+function approveNaturalVclSmokePlan(card, state) {
+  if ((state.status || '') !== 'awaitingApproval' ||
+      naturalVclSmoke.planApproved) return false;
+  if (requestInProgress) {
+    naturalVclSmoke.pendingApproval = { card, state };
+    return true;
+  }
+  const approveButton = [...card.querySelectorAll('.agent-control-button')]
+    .find(button => button.textContent === 'Approve plan');
+  if (!approveButton || approveButton.disabled) return true;
+  naturalVclSmoke.planApproved = true;
+  approveButton.click();
+  return true;
+}
+
+function finishNaturalVclSmokeFromState(status, state, stateSteps) {
+  if (status === 'completed') {
+    const required = [
+      'PreviewProjectTemplate',
+      'CreateProjectFromTemplate',
+      'OpenCreatedProject',
+      'BuildProject',
+      'StartDebugging'
+    ];
+    const complete = required.every(toolName => stateSteps.some(
+      step => step.toolName === toolName && step.success === true
+    ));
+    finishNaturalVclSmoke(complete ? 'passed' : 'failed',
+      complete ? '' : 'completed-before-required-evidence', state);
+    return;
+  }
+  if (status === 'failed' && state.recoveryInput === 'destination' &&
+      !naturalVclSmoke.destinationRetried) {
+    naturalVclSmoke.recoveryStateObserved = true;
+    trySubmitNaturalVclRecovery();
+    return;
+  }
+  if (status === 'failed' && naturalVclSmoke.recoveryPending) return;
+  if (status === 'failed' || status === 'cancelled') {
+    finishNaturalVclSmoke('failed', `agent-${status}`, state);
+  }
+}
+
 function continueNaturalVclSmoke(card, state) {
   if (!naturalVclSmoke) return;
   const status = state.status || '';
@@ -3382,41 +3425,8 @@ function continueNaturalVclSmoke(card, state) {
       (status === 'failed' || status === 'cancelled')) {
     return;
   }
-  if (status === 'awaitingApproval' && !naturalVclSmoke.planApproved) {
-    if (requestInProgress) {
-      naturalVclSmoke.pendingApproval = { card, state };
-      return;
-    }
-    const approveButton = [...card.querySelectorAll('.agent-control-button')]
-      .find(button => button.textContent === 'Approve plan');
-    if (!approveButton || approveButton.disabled) return;
-    naturalVclSmoke.planApproved = true;
-    approveButton.click();
-    return;
-  }
-  if (status === 'completed') {
-    const steps = stateSteps;
-    const required = [
-      'PreviewProjectTemplate',
-      'CreateProjectFromTemplate',
-      'OpenCreatedProject',
-      'BuildProject',
-      'StartDebugging'
-    ];
-    const complete = required.every(toolName => steps.some(
-      step => step.toolName === toolName && step.success === true
-    ));
-    finishNaturalVclSmoke(complete ? 'passed' : 'failed',
-      complete ? '' : 'completed-before-required-evidence', state);
-  } else if (status === 'failed' && state.recoveryInput === 'destination' &&
-      !naturalVclSmoke.destinationRetried) {
-    naturalVclSmoke.recoveryStateObserved = true;
-    trySubmitNaturalVclRecovery();
-  } else if (status === 'failed' && naturalVclSmoke.recoveryPending) {
-    return;
-  } else if (status === 'failed' || status === 'cancelled') {
-    finishNaturalVclSmoke('failed', `agent-${status}`, state);
-  }
+  if (approveNaturalVclSmokePlan(card, state)) return;
+  finishNaturalVclSmokeFromState(status, state, stateSteps);
 }
 
 globalThis.beginNaturalVclSmoke = function beginNaturalVclSmoke(
@@ -4839,6 +4849,17 @@ function updateModelsList(models, activeModel, enabled = true) {
   updateComposerRoute();
 }
 
+function continueNaturalVclSmokeAfterRequest() {
+  if (naturalVclSmoke?.recoveryStateObserved &&
+      naturalVclSmoke.recoveryRequestReady) {
+    trySubmitNaturalVclRecovery();
+  }
+  if (!naturalVclSmoke?.pendingApproval) return;
+  naturalVclSmoke.pendingApproval = null;
+  naturalVclSmoke.planApproved = true;
+  postMessageToDelphi({ action: 'approve_agent' });
+}
+
 function setRequestState(inProgress) {
   console.log('[DEBUG] setRequestState called with:', inProgress);
   requestInProgress = inProgress;
@@ -4868,15 +4889,7 @@ function setRequestState(inProgress) {
     providerDropdownTrigger.setAttribute('aria-disabled', 'false');
     btnQueuePrompt.classList.add('hidden');
     promptTextarea.placeholder = 'Ask Rad IA or type / for commands...';
-    if (naturalVclSmoke?.recoveryStateObserved &&
-        naturalVclSmoke.recoveryRequestReady) {
-      trySubmitNaturalVclRecovery();
-    }
-    if (naturalVclSmoke?.pendingApproval) {
-      naturalVclSmoke.pendingApproval = null;
-      naturalVclSmoke.planApproved = true;
-      postMessageToDelphi({ action: 'approve_agent' });
-    }
+    continueNaturalVclSmokeAfterRequest();
   }
   applyModelSelectionState();
   executionRouteSelector.disabled = inProgress;

--- a/Tests/Source/RadIA.Tests.AgentRuntime.pas
+++ b/Tests/Source/RadIA.Tests.AgentRuntime.pas
@@ -978,11 +978,13 @@ var
   LDecisionProvider: IRadIAAgentDecisionProvider;
   LEvent: TEvent;
   LExecutor: IRadIAToolExecutor;
+  LFinishedAfterRelease: Boolean;
   LResult: TRadIAAgentRunResult;
   LService: IRadIAService;
   LStateJson: string;
   LStore: IRadIAAgentCheckpointStore;
 begin
+  LFinishedAfterRelease := False;
   LEvent := TEvent.Create(nil, True, False, '');
   try
     LService := TRadIAMockAgentService.Create(
@@ -1007,6 +1009,7 @@ begin
       end,
       procedure(const ARunResult: TRadIAAgentRunResult)
       begin
+        LFinishedAfterRelease := not LController.IsRunning;
         LResult := ARunResult;
         LEvent.SetEvent;
       end
@@ -1021,6 +1024,7 @@ begin
 
     Assert.AreEqual(wrSignaled, LEvent.WaitFor(5000));
     Assert.AreEqual(asCompleted, LResult.Status);
+    Assert.IsTrue(LFinishedAfterRelease);
     Assert.AreEqual('Async objective completed.', LResult.Message);
     Assert.Contains(LStateJson, '"status":"completed"');
   finally

--- a/Tests/Source/RadIA.Tests.AgentRuntime.pas
+++ b/Tests/Source/RadIA.Tests.AgentRuntime.pas
@@ -180,7 +180,9 @@ type
     [Test]
     procedure TestStopsRepeatedToolCalls;
     [Test]
-    procedure TestStopsDuplicateArtifactRangeImmediately;
+    procedure TestRecoversDuplicateCompletedArtifactRange;
+    [Test]
+    procedure TestReportsDestinationRecoveryAfterExistingDirectory;
     [Test]
     procedure TestPauseAndResumeFromCheckpoint;
     [Test]
@@ -205,6 +207,8 @@ type
     procedure TestProviderRejectsInvalidDecision;
     [Test]
     procedure TestProviderBuildsDecisionFromService;
+    [Test]
+    procedure TestProviderLimitsProjectCreationToolCatalog;
     [Test]
     procedure TestControllerRunsAgentAsynchronously;
     [Test]
@@ -1313,6 +1317,41 @@ begin
   Assert.Contains(LDecision.ArgumentsJson, '"path":"unit.pas"');
   Assert.Contains(LServiceObject.Prompt, 'CURRENT_STATE:');
   Assert.Contains(LServiceObject.Prompt, '{"objective":"Inspect"}');
+  Assert.Contains(
+    LServiceObject.Prompt,
+    'When GetToolResultRange returns hasMore=false'
+  );
+end;
+
+procedure TTestRadIAAgentRuntime.TestProviderLimitsProjectCreationToolCatalog;
+var
+  LProvider: IRadIAAgentDecisionProvider;
+  LService: IRadIAService;
+  LServiceObject: TRadIAMockAgentService;
+begin
+  LServiceObject := TRadIAMockAgentService.Create(
+    '{"kind":"complete","message":"Done."}'
+  );
+  LService := LServiceObject;
+  LProvider := TRadIAAgentServiceDecisionProvider.Create(
+    LService,
+    [],
+    TRadIAAgentProviderSettings.Default(
+      '[{"name":"BuildProject"},{"name":"ReadFile"},' +
+        '{"name":"CreateProjectFromTemplate"}]'
+    )
+  );
+
+  LProvider.NextDecision(
+    '{"objective":"Create a Delphi project from the user requirements."}'
+  );
+
+  Assert.Contains(LServiceObject.Prompt, '"name":"BuildProject"');
+  Assert.Contains(
+    LServiceObject.Prompt,
+    '"name":"CreateProjectFromTemplate"'
+  );
+  Assert.DoesNotContain(LServiceObject.Prompt, '"name":"ReadFile"');
 end;
 
 procedure TTestRadIAAgentRuntime.TestProviderParsesFencedCompletion;
@@ -1448,17 +1487,29 @@ begin
   end;
 end;
 
-procedure TTestRadIAAgentRuntime.TestStopsDuplicateArtifactRangeImmediately;
+procedure TTestRadIAAgentRuntime.TestRecoversDuplicateCompletedArtifactRange;
 var
   LExecutor: IRadIAToolExecutor;
+  LExecutorObject: TRadIAMockAgentToolExecutor;
   LProvider: IRadIAAgentDecisionProvider;
+  LResultDirectory: string;
+  LResultStore: IRadIAAgentResultStore;
   LStore: IRadIAAgentCheckpointStore;
+  LStoreObject: TRadIAMemoryAgentCheckpointStore;
   LRuntime: TRadIAAgentRuntime;
   LResult: TRadIAAgentRunResult;
 begin
-  LExecutor := TRadIAMockAgentToolExecutor.Create(
-    TRadIAToolResult.Succeeded('{"content":"same range"}')
+  LResultDirectory := TPath.Combine(
+    TPath.GetTempPath,
+    'RadIA-ArtifactRecoveryResult-' + TGUID.NewGuid.ToString
   );
+  LExecutorObject := TRadIAMockAgentToolExecutor.Create(
+    TRadIAToolResult.Succeeded(
+      '{"content":"same range","returnedCharacters":10,' +
+      '"totalCharacters":10,"hasMore":false}'
+    )
+  );
+  LExecutor := LExecutorObject;
   LProvider := TRadIAMockAgentDecisionProvider.Create([
     TRadIAAgentDecision.Plan(
       'Review artifact recovery.',
@@ -1471,10 +1522,20 @@ begin
     TRadIAAgentDecision.CallTool(
       'GetToolResultRange',
       '{"artifactId":"artifact-1","offset":0,"length":100}'
-    )
+    ),
+    TRadIAAgentDecision.Complete('Artifact reviewed.')
   ]);
-  LStore := TRadIAMemoryAgentCheckpointStore.Create;
-  LRuntime := NewRuntime(LExecutor, LProvider, LStore);
+  LStoreObject := TRadIAMemoryAgentCheckpointStore.Create;
+  LStore := LStoreObject;
+  LResultStore := TRadIAAgentFileResultStore.Create(LResultDirectory);
+  LRuntime := TRadIAAgentRuntime.Create(
+    LExecutor,
+    LProvider,
+    LStore,
+    nil,
+    TRadIAResultCompactor.Create,
+    LResultStore
+  );
   try
     LResult := LRuntime.Start(
       'Recover one artifact range.',
@@ -1484,9 +1545,60 @@ begin
     );
     Assert.AreEqual(asAwaitingApproval, LResult.Status);
     LResult := LRuntime.Resume('duplicate-artifact-range-session');
+    Assert.AreEqual(asCompleted, LResult.Status);
+    Assert.AreEqual(2, LResult.StepCount);
+    Assert.AreEqual(1, LExecutorObject.CallCount);
+    Assert.Contains(
+      LStoreObject.SnapshotJson,
+      'artifact_range_already_complete'
+    );
+    Assert.DoesNotContain(
+      LStoreObject.SnapshotJson,
+      '"resultArtifactId"'
+    );
+  finally
+    LRuntime.Free;
+    if TDirectory.Exists(LResultDirectory) then
+      TDirectory.Delete(LResultDirectory, True);
+  end;
+end;
+
+procedure TTestRadIAAgentRuntime.
+  TestReportsDestinationRecoveryAfterExistingDirectory;
+var
+  LExecutor: IRadIAToolExecutor;
+  LProvider: IRadIAAgentDecisionProvider;
+  LRuntime: TRadIAAgentRuntime;
+  LResult: TRadIAAgentRunResult;
+  LStore: IRadIAAgentCheckpointStore;
+begin
+  LExecutor := TRadIAMockAgentToolExecutor.Create(
+    TRadIAToolResult.Failed(
+      'tool_execution_failed',
+      'Project destination folder must be empty.'
+    )
+  );
+  LProvider := TRadIAMockAgentDecisionProvider.Create([
+    TRadIAAgentDecision.Plan(
+      'Create the requested project.',
+      '[{"title":"Create project"}]'
+    ),
+    TRadIAAgentDecision.CallTool('CreateProjectFromTemplate', '{}'),
+    TRadIAAgentDecision.Fail('Choose another destination.')
+  ]);
+  LStore := TRadIAMemoryAgentCheckpointStore.Create;
+  LRuntime := NewRuntime(LExecutor, LProvider, LStore);
+  try
+    LResult := LRuntime.Start(
+      'Create a calculator with operation history.',
+      'destination-recovery-session',
+      '',
+      TRadIAAgentLimits.Default
+    );
+    Assert.AreEqual(asAwaitingApproval, LResult.Status);
+    LResult := LRuntime.Resume('destination-recovery-session');
     Assert.AreEqual(asFailed, LResult.Status);
-    Assert.AreEqual(1, LResult.StepCount);
-    Assert.Contains(LResult.Message, 'repeated too many times');
+    Assert.AreEqual('destination', LResult.RecoveryInput);
   finally
     LRuntime.Free;
   end;

--- a/Tests/Source/RadIA.Tests.Journeys.pas
+++ b/Tests/Source/RadIA.Tests.Journeys.pas
@@ -39,6 +39,8 @@ type
     procedure NaturalPromptsNormalizeEverySupportedTemplate;
     [Test]
     procedure ReplacesOnlyCreateDestinationDuringRecovery;
+    [Test]
+    procedure PrependsRecoveryDestinationToLegacyContext;
   end;
 
 implementation
@@ -47,12 +49,24 @@ uses
   System.SysUtils,
   RadIA.Core.Journeys;
 
+procedure TTestRadIAJourneys.PrependsRecoveryDestinationToLegacyContext;
+var
+  LContext: string;
+begin
+  LContext := TRadIAJourneyCatalog.ReplaceCreateDestination(
+    'Create a calculator with operation history',
+    'D:\New\Calculator'
+  );
+  Assert.StartsWith('destination="D:\New\Calculator" ', LContext);
+  Assert.Contains(LContext, 'operation history');
+end;
+
 procedure TTestRadIAJourneys.ReplacesOnlyCreateDestinationDuringRecovery;
 var
   LContext: string;
 begin
   LContext := TRadIAJourneyCatalog.ReplaceCreateDestination(
-    'Create a calculator with operation history ' +
+    'Create a calculator with operation history in D:\Old\Calculator ' +
       'destination="D:\Old\Calculator" project="CalculatorApp" ' +
       'type="VCL" platform="Win32" feature="operationHistory"',
     'D:\New\Calculator'

--- a/Tests/Source/RadIA.Tests.Journeys.pas
+++ b/Tests/Source/RadIA.Tests.Journeys.pas
@@ -37,6 +37,8 @@ type
     procedure NaturalCalculatorHistoryPreservesFunctionalFeature;
     [Test]
     procedure NaturalPromptsNormalizeEverySupportedTemplate;
+    [Test]
+    procedure ReplacesOnlyCreateDestinationDuringRecovery;
   end;
 
 implementation
@@ -44,6 +46,23 @@ implementation
 uses
   System.SysUtils,
   RadIA.Core.Journeys;
+
+procedure TTestRadIAJourneys.ReplacesOnlyCreateDestinationDuringRecovery;
+var
+  LContext: string;
+begin
+  LContext := TRadIAJourneyCatalog.ReplaceCreateDestination(
+    'Create a calculator with operation history ' +
+      'destination="D:\Old\Calculator" project="CalculatorApp" ' +
+      'type="VCL" platform="Win32" feature="operationHistory"',
+    'D:\New\Calculator'
+  );
+  Assert.Contains(LContext, 'destination="D:\New\Calculator"');
+  Assert.DoesNotContain(LContext, 'D:\Old\Calculator');
+  Assert.Contains(LContext, 'Create a calculator with operation history');
+  Assert.Contains(LContext, 'project="CalculatorApp"');
+  Assert.Contains(LContext, 'feature="operationHistory"');
+end;
 
 procedure TTestRadIAJourneys.CatalogContainsFiveEndToEndJourneys;
 var

--- a/Tests/Source/RadIA.Tests.Providers.pas
+++ b/Tests/Source/RadIA.Tests.Providers.pas
@@ -11,6 +11,11 @@ type
   protected
     function GetCodexExecutablePath: string; override;
   public
+    function CodexCommandLine(
+      const ACodexPath: string;
+      const AModel: string;
+      const AThreadId: string = ''
+    ): string;
     function IsUsingCodexCliTransport: Boolean;
   end;
 
@@ -62,6 +67,8 @@ type
     [Test]
     procedure TestOpenAI_LegacyOAuthAndProUseCodexCli;
     [Test]
+    procedure TestOpenAI_CodexTransportIgnoresUserTools;
+    [Test]
     procedure TestOpenAI_SendPromptAsync_CliOAuth_CodexNotFound;
     [Test]
     procedure TestOpenAI_SendPromptStreamAsync_CliOAuth_CodexNotFound;
@@ -92,9 +99,42 @@ begin
   Result := '';
 end;
 
+function TTestRadIAOpenAIProvider.CodexCommandLine(
+  const ACodexPath: string;
+  const AModel: string;
+  const AThreadId: string
+): string;
+begin
+  Result := BuildCodexCommandLine(ACodexPath, AModel, AThreadId);
+end;
+
 function TTestRadIAOpenAIProvider.IsUsingCodexCliTransport: Boolean;
 begin
   Result := UsesCodexCliTransport;
+end;
+
+procedure TTestRadIAProviders.TestOpenAI_CodexTransportIgnoresUserTools;
+var
+  LCommandLine: string;
+begin
+  LCommandLine := FOpenAIProv.CodexCommandLine(
+    'C:\Tools\codex.exe',
+    'gpt-5.6-luna'
+  );
+  Assert.Contains(LCommandLine, '--ignore-user-config');
+  Assert.Contains(LCommandLine, '--sandbox read-only');
+  Assert.IsFalse(LCommandLine.Contains('--ephemeral'));
+  LCommandLine := FOpenAIProv.CodexCommandLine(
+    'C:\Tools\codex.exe',
+    'gpt-5.6-luna',
+    'thread-1'
+  );
+  Assert.Contains(
+    LCommandLine,
+    'exec --sandbox read-only --ignore-user-config resume'
+  );
+  Assert.Contains(LCommandLine, '--ignore-user-config');
+  Assert.Contains(LCommandLine, '--sandbox read-only');
 end;
 
 { TTestRadIAProviders }

--- a/Tests/Source/RadIA.Tests.ResultCompactor.pas
+++ b/Tests/Source/RadIA.Tests.ResultCompactor.pas
@@ -31,6 +31,8 @@ type
     procedure PreservesDiffHeadersInsideLargeDiff;
     [Test]
     procedure CompactsLargeWorkspaceListWithProvenance;
+    [Test]
+    procedure PrefersSemanticRuntimeControlsOverDuplicateNativeControls;
   end;
 
 implementation
@@ -266,6 +268,36 @@ begin
   Assert.Contains(LCompaction.CompactedJson, 'Unit001.pas');
   Assert.Contains(LCompaction.CompactedJson, 'Unit100.pas');
   Assert.Contains(LCompaction.CompactedJson, '"omittedItems":50');
+end;
+
+procedure TTestRadIAResultCompactor.
+  PrefersSemanticRuntimeControlsOverDuplicateNativeControls;
+var
+  LCompaction: TRadIAResultCompaction;
+begin
+  LCompaction := TRadIAResultCompactor.Compact(
+    'GetRuntimeControlTree',
+    '{"windowId":"window-1","controls":[' +
+      '{"controlId":"native","parentId":"window-1",' +
+      '"className":"TButton","text":"Clear history",' +
+      '"path":"TButton[0]","capabilities":["invoke"]},' +
+      '{"controlId":"form","parentId":"",' +
+      '"className":"TRadIAMainForm","text":"CalculatorApp",' +
+      '"path":"RadIAMainForm","capabilities":["close"]},' +
+      '{"controlId":"semantic","parentId":"form",' +
+      '"className":"TButton","text":"Clear history",' +
+      '"path":"RadIAMainForm/ClearHistoryButton",' +
+      '"capabilities":["invoke"]}],"count":3}'
+  );
+  Assert.IsTrue(LCompaction.Compacted);
+  Assert.Contains(LCompaction.CompactedJson, '"controlId":"semantic"');
+  Assert.Contains(LCompaction.CompactedJson, '"controlId":"form"');
+  Assert.DoesNotContain(LCompaction.CompactedJson, '"controlId":"native"');
+  Assert.Contains(
+    LCompaction.CompactedJson,
+    '"omittedDuplicateControls":1'
+  );
+  Assert.Contains(LCompaction.CompactedJson, '"count":2');
 end;
 
 initialization

--- a/Tests/Usage/usage-matrix.json
+++ b/Tests/Usage/usage-matrix.json
@@ -269,6 +269,9 @@
         "delphi13-ide64"
       ],
       "observableOutcomes": [
+        "existing-destination-recovered",
+        "original-requirements-preserved",
+        "native-orchestration-used",
         "project-opened",
         "build-passed",
         "application-ran",
@@ -276,6 +279,9 @@
       ],
       "requiredEvidence": [
         "recommendationAccepted",
+        "destinationRecovered",
+        "requirementsPreserved",
+        "nativeOrchestration",
         "previewSucceeded",
         "creationSucceeded",
         "projectOpened",

--- a/Tests/Web/RadIA.ConversationE2E.test.js
+++ b/Tests/Web/RadIA.ConversationE2E.test.js
@@ -8,6 +8,10 @@ const presenter = fs.readFileSync(
   'Source/UI/RadIA.UI.ChatPresenter.pas',
   'utf8'
 );
+const naturalVclRunner = fs.readFileSync(
+  'scripts/Test-RadIA.NaturalVclChatE2E.ps1',
+  'utf8'
+);
 
 test('conversation smoke submits through the real composer path', () => {
   assert.match(chatScript, /globalThis\.beginConversationSmoke/u);
@@ -84,7 +88,20 @@ test('natural VCL smoke accepts the real route and requires complete evidence', 
   assert.match(chatScript, /completed-before-required-evidence/u);
   assert.match(chatScript, /failedTool: failedStep\.toolName/u);
   assert.match(chatScript, /agentMessage: state\.message/u);
+  assert.match(chatScript, /state\.recoveryInput === 'destination'/u);
+  assert.match(chatScript, /naturalVclSmoke\.recoveryPending/u);
+  assert.match(chatScript, /recoveryRequestReady/u);
+  assert.match(chatScript, /recoveryStateObserved/u);
+  assert.match(chatScript, /handleJourneyInputRequested/u);
+  assert.match(chatScript, /retryObjectiveActive/u);
+  assert.match(chatScript, /destinationRecovered/u);
+  assert.match(chatScript, /requirementsPreserved/u);
+  assert.match(chatScript, /nativeOrchestration/u);
   assert.match(chatScript, /CLI task completed\./u);
+  assert.match(chatFrame, /RADIA_IDE_SMOKE_NATURAL_VCL_RETRY_DESTINATION/u);
+  assert.match(presenter, /journey_input_requested/u);
+  assert.match(naturalVclRunner, /New-Item -ItemType File/u);
+  assert.match(naturalVclRunner, /existing\.txt/u);
   assert.match(presenter, /not AObjective\.Contains/u);
   assert.match(presenter, /Create a Delphi project from the user requirements\./u);
 });

--- a/Tests/Web/RadIA.ConversationE2E.test.js
+++ b/Tests/Web/RadIA.ConversationE2E.test.js
@@ -92,18 +92,28 @@ test('natural VCL smoke accepts the real route and requires complete evidence', 
   assert.match(chatScript, /naturalVclSmoke\.recoveryPending/u);
   assert.match(chatScript, /recoveryRequestReady/u);
   assert.match(chatScript, /recoveryStateObserved/u);
+  assert.match(chatScript, /pendingApproval/u);
   assert.match(chatScript, /handleJourneyInputRequested/u);
   assert.match(chatScript, /retryObjectiveActive/u);
+  assert.match(chatScript, /retryPreviewActive/u);
+  assert.match(chatScript, /destinationRetried &&/u);
   assert.match(chatScript, /destinationRecovered/u);
   assert.match(chatScript, /requirementsPreserved/u);
   assert.match(chatScript, /nativeOrchestration/u);
   assert.match(chatScript, /CLI task completed\./u);
   assert.match(chatFrame, /RADIA_IDE_SMOKE_NATURAL_VCL_RETRY_DESTINATION/u);
   assert.match(presenter, /journey_input_requested/u);
+  assert.match(presenter, /FActiveJourneyContext := LContext/u);
+  assert.match(presenter, /FActiveJourneyDefinition := LDefinition/u);
+  assert.match(presenter, /FActiveJourneyNative := True/u);
   assert.match(naturalVclRunner, /New-Item -ItemType File/u);
   assert.match(naturalVclRunner, /existing\.txt/u);
   assert.match(presenter, /not AObjective\.Contains/u);
   assert.match(presenter, /Create a Delphi project from the user requirements\./u);
+  assert.ok(
+    presenter.indexOf('FNativeOrchestrationOverride :=') <
+      presenter.indexOf('if TryStartExternalAgentRun(AObjective')
+  );
 });
 
 test('session isolation smoke rejects a pending action after chat switch', () => {

--- a/Tests/Web/RadIA.ExecutionRouteCopy.test.js
+++ b/Tests/Web/RadIA.ExecutionRouteCopy.test.js
@@ -61,6 +61,11 @@ test('chat exposes the effective route independently from agent mode', () => {
   assert.match(presenter, /LEffective := ResolveEffectiveExecutionSettings/u);
   assert.match(presenter, /if ASettings\.Kind = aekCli then/u);
   assert.match(presenter, /AOrchestrator := 'external-cli'/u);
+  assert.match(presenter, /FNativeOrchestrationOverride/u);
+  assert.match(
+    presenter,
+    /if FNativeOrchestrationOverride or[\s\S]*?SameText\(LEffective\.Values\.ExecutorId, 'native'\)/u
+  );
   assert.match(presenter, /Exit\('Chat \| ' \+ ACliClientId \+ ' CLI direct'\)/u);
   assert.match(presenter, /ChatGPT Pro via Codex CLI/u);
   assert.match(chatJs, /executionRouteSelector\.disabled = requestInProgress/u);

--- a/Tests/Web/RadIA.IntentRecommendation.test.js
+++ b/Tests/Web/RadIA.IntentRecommendation.test.js
@@ -32,6 +32,15 @@ test('host validates recommendation actions against pending state', () => {
   assert.match(presenter, /dismiss_intent_recommendation/u);
 });
 
+test('accepted recommendation is visibly consumed before execution starts', () => {
+  assert.match(chatScript, /intent-recommendation-resolved/u);
+  assert.match(chatScript, /Starting recommended route…/u);
+  assert.match(
+    chatScript,
+    /querySelector\('\.intent-recommendation-controls'\)[\s\S]*?replaceChildren\(status\)/u
+  );
+});
+
 test('natural intent creates a recommendation instead of direct journey execution', () => {
   assert.match(presenter, /TRadIAIntentRouter\.TryRecommend/u);
   assert.match(presenter, /PostIntentRecommendation\(LRecommendation\)/u);

--- a/Tests/Web/RadIA.OperationalExperience.test.js
+++ b/Tests/Web/RadIA.OperationalExperience.test.js
@@ -42,6 +42,17 @@ test('technical agent details remain available below the simplified summary', ()
   assert.match(chatScript, /Technical details/u);
 });
 
+test('persisted string plan steps keep their real titles', () => {
+  assert.match(
+    chatScript,
+    /typeof planStep === 'string' \? planStep\.trim\(\) : ''/u
+  );
+  assert.match(
+    chatScript,
+    /const title = stringStep \|\| planStep\?\.title \|\| 'Planned step'/u
+  );
+});
+
 test('optional project additions are user-initiated after completion', () => {
   assert.match(chatScript, /state\.status !== 'completed'/u);
   assert.match(chatScript, /Add DUnitX tests/u);

--- a/docs/development/usage_test_matrix.en.md
+++ b/docs/development/usage_test_matrix.en.md
@@ -91,6 +91,10 @@ powershell.exe -ExecutionPolicy Bypass `
 
 Use `-PlanOnly` first to inspect cost and combinations without opening Delphi.
 
+`natural-vcl-project-creation` deliberately starts with an existing directory. The scenario passes only
+when the simulated user supplies another destination, the original requirements remain in the objective,
+execution stays on the native orchestrator, and the project is created, opened, built, and started.
+
 The `targeted` profile uses the already installed build and never silently replaces a developer's IDE.
 Explicitly install the intended revision with `build.ps1 -Install` first. The `startup`, `release`, and
 `regression` profiles build and install their own packages per target.

--- a/docs/development/usage_test_matrix.md
+++ b/docs/development/usage_test_matrix.md
@@ -97,6 +97,10 @@ seleção: UI usa `chat-window-state-persistence`; agente usa `agent-step-budget
 `calculator-history-fidelity`; testes e reparo usam `build-failure-repair` e
 `dunitx-create-run-repair`.
 
+`natural-vcl-project-creation` começa deliberadamente com uma pasta já existente. O cenário só passa
+quando o usuário simulado informa outro destino, os requisitos originais permanecem no objetivo, a
+execução continua no orquestrador nativo e o projeto é criado, aberto, compilado e iniciado.
+
 O perfil `targeted` usa o build já instalado e nunca troca silenciosamente a IDE do desenvolvedor. Instale
 explicitamente a revisão desejada com `build.ps1 -Install` antes de executá-lo. Os perfis `startup`,
 `release` e `regression` geram e instalam seus próprios pacotes por alvo.

--- a/docs/guides/agent_result_compaction.en.md
+++ b/docs/guides/agent_result_compaction.en.md
@@ -27,6 +27,8 @@ default is 120,000. `RADIA_RESULT_COMPACTION_PROFILE` can temporarily override t
 - Tools without a known rule pass through unchanged.
 - A projection is applied only when it is smaller than the original JSON.
 - Parsing or validation failure falls back to the original JSON.
+- Runtime control trees prefer semantic paths and remove native duplicates when both represent the same
+  form, without removing the window root.
 
 ## Preservation and recovery
 
@@ -39,6 +41,10 @@ Compacted context reports `artifactId`, hash, size, and `fullResultAvailable`. T
 
 - `GetToolResultSummary` to confirm hash, size, and step;
 - `GetToolResultRange` to recover up to 65,536 characters per call.
+
+A response with `hasMore=false` completes recovery for that range. RadIA does not turn this tool result
+into another artifact and, if the model immediately repeats the same read, returns structured guidance
+to continue functional validation. A further repetition is still stopped by the safety limit.
 
 Both tools enforce the active session and reject traversal, session spoofing, and invalid ranges.
 Checkpoints, replay, UI, and validation gates preserve the reference. After retention evicts an old

--- a/docs/guides/agent_result_compaction.md
+++ b/docs/guides/agent_result_compaction.md
@@ -26,6 +26,8 @@ Abra **Tools > Options > Rad IA > General / Logs**.
 - Ferramentas sem regra conhecida usam passthrough.
 - A projeção só é aplicada quando fica menor que o JSON original.
 - Falha de parsing ou validação usa fallback automático para o JSON original.
+- Árvores de controles em execução preferem paths semânticos e removem duplicatas nativas quando ambas
+  representam o mesmo formulário, sem eliminar a raiz da janela.
 
 ## Preservação e recuperação
 
@@ -38,6 +40,11 @@ O contexto compactado informa `artifactId`, hash, tamanho e `fullResultAvailable
 
 - `GetToolResultSummary`, para confirmar hash, tamanho e etapa;
 - `GetToolResultRange`, para recuperar até 65.536 caracteres por chamada.
+
+Uma resposta com `hasMore=false` encerra a recuperação daquele intervalo. O RadIA não transforma o
+resultado dessa ferramenta em outro artefato e, se o modelo repetir imediatamente a mesma leitura,
+devolve uma orientação estruturada para continuar a validação funcional. Uma nova repetição ainda é
+interrompida pelo limite de segurança.
 
 As ferramentas respeitam a sessão ativa, rejeitam traversal, spoofing de sessão e ranges inválidos.
 Checkpoints, replay, UI e validation gates preservam a referência. Após a retenção remover um

--- a/docs/guides/cli_executors.en.md
+++ b/docs/guides/cli_executors.en.md
@@ -144,6 +144,13 @@ native.
 - The selection does not enable automatic approval options for CLIs.
 - MCP continues to be provisioned and diagnosed separately.
 
+When Codex CLI transports decisions for the native orchestrator, RadIA starts an isolated, read-only
+session without loading the user's `config.toml`. The session retains the identifier required to continue
+decisions for the same agent. Codex authentication remains available, while MCP tools, rules, and external
+settings cannot execute IDE operations outside the audited native executor. During creation journeys, the
+interface shows the effective native orchestrator even when the persisted preference for other tasks is a
+CLI executor.
+
 This configuration establishes the profiles and persistent preference used by the described transport
 next.
 

--- a/docs/guides/cli_executors.md
+++ b/docs/guides/cli_executors.md
@@ -145,6 +145,13 @@ arquivos ou variáveis de ambiente.
 - A seleção não habilita opções de aprovação automática dos CLIs.
 - MCP continua sendo provisionado e diagnosticado separadamente.
 
+Quando o Codex CLI transporta decisões do orquestrador nativo, o RadIA inicia uma sessão isolada,
+somente leitura e sem carregar o `config.toml` do usuário. A sessão mantém o identificador necessário
+para continuar as decisões do mesmo agente. A autenticação do Codex continua válida, mas ferramentas
+MCP, regras e configurações externas não podem executar operações IDE fora do executor nativo auditado.
+Em jornadas de criação, a interface mostra o orquestrador nativo efetivo mesmo quando a preferência
+persistida para outras tarefas é um executor CLI.
+
 Essa configuração estabelece os perfis e a preferência persistente usados pelo transporte descrito
 a seguir.
 

--- a/docs/guides/mcp_integration_guide.en.md
+++ b/docs/guides/mcp_integration_guide.en.md
@@ -195,7 +195,7 @@ For reproducible automation, prefer `mcp.<pid>.json`.
 1. Open Delphi and a project.
 2. Confirm that `mcp.<pid>.json` exists.
 3. Start or reload the MCP server in the client.
-4. Verify that `initialize` reports RadIA `2.17.5`.
+4. Verify that `initialize` reports RadIA `2.17.6`.
 5. Call `tools/list`.
 6. Call `GetIDEState` and `GetActiveProject`.
 7. Test mutable consent only in a disposable project.

--- a/docs/guides/mcp_integration_guide.md
+++ b/docs/guides/mcp_integration_guide.md
@@ -215,7 +215,7 @@ Para automação reproduzível, prefira sempre `mcp.<pid>.json`.
 1. Abra o Delphi e um projeto.
 2. Confirme que `mcp.<pid>.json` foi criado.
 3. Inicie ou recarregue o servidor no cliente MCP.
-4. Verifique que `initialize` retorna RadIA `2.17.5`.
+4. Verifique que `initialize` retorna RadIA `2.17.6`.
 5. Execute `tools/list`.
 6. Chame `GetIDEState` e `GetActiveProject`.
 7. Para testar consentimento, use uma tool mutável somente em um projeto descartável.

--- a/docs/guides/user_guide_journeys.en.md
+++ b/docs/guides/user_guide_journeys.en.md
@@ -79,6 +79,11 @@ each completed operation in order and provides **Clear history**. The journey ca
 running real calculations, checking the history, and verifying that it can be cleared; a green build
 alone does not satisfy this request.
 
+If the destination directory already exists, the run reports the conflict and keeps the journey waiting
+for another destination. The next reply replaces only the path: project type, platform, name, and
+functional requirements — including history — remain in the objective. The recommendation card is
+visibly consumed on the first click so it does not suggest that the same action is still available.
+
 ## Execution model
 
 1. The command visually enables agent mode when necessary.

--- a/docs/guides/user_guide_journeys.md
+++ b/docs/guides/user_guide_journeys.md
@@ -79,6 +79,11 @@ cada operação concluída em ordem e oferece **Clear history**. A jornada só p
 executar cálculos reais, conferir o histórico e verificar sua limpeza; um build verde, isoladamente,
 não atende esse pedido.
 
+Se a pasta de destino já existir, a execução informa o conflito e mantém a jornada aguardando outro
+destino. A resposta seguinte substitui somente o caminho: tipo do projeto, plataforma, nome e requisitos
+funcionais — inclusive o histórico — continuam no objetivo. O cartão de recomendação é consumido
+visualmente no primeiro clique para não sugerir que a mesma ação ainda está disponível.
+
 ## Como a execução funciona
 
 1. O comando ativa visualmente o modo agente quando necessário.

--- a/docs/guides/user_manual.en.md
+++ b/docs/guides/user_manual.en.md
@@ -1,4 +1,4 @@
-# Complete RadIA 2.17.5 user manual
+# Complete RadIA 2.17.6 user manual
 
 > Use `/help` to compare Chat, Agent, CLI, and MCP. When a plan awaits approval, select
 > **Approve plan** or type `/agent resume`.
@@ -36,7 +36,7 @@ layouts such as `Startup Layout` and `Debug Layout`. If the panel is closed befo
 remains closed in the next session; use `Tools > RadIA > Chat` to open it again.
 
 The chat panel caption and primary RadIA windows show the loaded version, for example
-`Rad IA Chat v2.17.5`, so support can confirm the installed build quickly.
+`Rad IA Chat v2.17.6`, so support can confirm the installed build quickly.
 
 Supported credentials are protected locally with Windows DPAPI. Ollama and LM Studio can run
 locally. See the [installation guide](../getting-started/install_config.en.md).

--- a/docs/guides/user_manual.md
+++ b/docs/guides/user_manual.md
@@ -1,4 +1,4 @@
-# Manual completo do RadIA 2.17.5
+# Manual completo do RadIA 2.17.6
 
 > Para comparar Chat, Agent, CLI e MCP, use `/help`. Quando um plano aguardar aprovação, clique em
 > **Approve plan** ou digite `/agent resume`.
@@ -45,7 +45,7 @@ troca entre layouts nomeados, como `Startup Layout` e `Debug Layout`. Se o paine
 de sair, ele permanece fechado na sessão seguinte; use `Tools > RadIA > Chat` para abri-lo novamente.
 
 O caption do painel de chat e das janelas principais do RadIA mostra a versão carregada, por exemplo
-`Rad IA Chat v2.17.5`, para facilitar suporte e conferência de instalação.
+`Rad IA Chat v2.17.6`, para facilitar suporte e conferência de instalação.
 
 Se o painel ou package não aparecer:
 

--- a/docs/reference/cli_capability_matrix.en.md
+++ b/docs/reference/cli_capability_matrix.en.md
@@ -15,7 +15,7 @@
 
 ## Current matrix
 
-| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.5 use |
+| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.6 use |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Yes, JSONL | Structured event | `exec resume <id>` | Yes | Yes | Not declared | New execution per message |
 | Claude Code | Yes, stream JSON | Structured event | `--resume <id>` | Yes | Yes | Not declared | New execution per message |

--- a/docs/reference/cli_capability_matrix.md
+++ b/docs/reference/cli_capability_matrix.md
@@ -15,7 +15,7 @@
 
 ## Matriz atual
 
-| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.5 |
+| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.6 |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Sim, JSONL | Evento estruturado | `exec resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |
 | Claude Code | Sim, stream JSON | Evento estruturado | `--resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radia-plugin",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "description": "Rad IA - AI Assistant for Delphi IDE",
   "main": "eslint.config.js",
   "scripts": {

--- a/scripts/Test-RadIA.NaturalVclChatE2E.ps1
+++ b/scripts/Test-RadIA.NaturalVclChatE2E.ps1
@@ -15,7 +15,11 @@ $validationRoot = [IO.Path]::GetFullPath(
 )
 New-Item -ItemType Directory -Path $validationRoot -Force | Out-Null
 $journeyRoot = Join-Path $validationRoot ([Guid]::NewGuid().ToString("N"))
+$initialDestination = Join-Path $journeyRoot "ExistingCalculator"
 $destination = Join-Path $journeyRoot "RadIAUserCalculator"
+New-Item -ItemType Directory -Path $initialDestination -Force | Out-Null
+New-Item -ItemType File -Path (Join-Path $initialDestination "existing.txt") `
+    -Force | Out-Null
 $resolvedEvidence = [IO.Path]::GetFullPath($EvidencePath)
 New-Item -ItemType Directory -Path (Split-Path -Parent $resolvedEvidence) `
     -Force | Out-Null
@@ -26,6 +30,7 @@ if (Test-Path -LiteralPath $resolvedEvidence) {
 $previousValues = @{
     Evidence = $env:RADIA_IDE_SMOKE_NATURAL_VCL
     Destination = $env:RADIA_IDE_SMOKE_NATURAL_VCL_DESTINATION
+    RetryDestination = $env:RADIA_IDE_SMOKE_NATURAL_VCL_RETRY_DESTINATION
     Root = $env:RADIA_IDE_SMOKE_NATURAL_VCL_ROOT
     DelphiVersion = $env:RADIA_IDE_SMOKE_DELPHI_VERSION
     Platform = $env:RADIA_IDE_SMOKE_TARGET_PLATFORM
@@ -33,7 +38,8 @@ $previousValues = @{
 }
 try {
     $env:RADIA_IDE_SMOKE_NATURAL_VCL = $resolvedEvidence
-    $env:RADIA_IDE_SMOKE_NATURAL_VCL_DESTINATION = $destination
+    $env:RADIA_IDE_SMOKE_NATURAL_VCL_DESTINATION = $initialDestination
+    $env:RADIA_IDE_SMOKE_NATURAL_VCL_RETRY_DESTINATION = $destination
     $env:RADIA_IDE_SMOKE_NATURAL_VCL_ROOT = $journeyRoot
     $env:RADIA_IDE_SMOKE_DELPHI_VERSION = $DelphiVersion
     $env:RADIA_IDE_SMOKE_TARGET_PLATFORM = if ($IDE64) { "Win64" } else { "Win32" }
@@ -55,6 +61,8 @@ try {
 } finally {
     $env:RADIA_IDE_SMOKE_NATURAL_VCL = $previousValues.Evidence
     $env:RADIA_IDE_SMOKE_NATURAL_VCL_DESTINATION = $previousValues.Destination
+    $env:RADIA_IDE_SMOKE_NATURAL_VCL_RETRY_DESTINATION = `
+        $previousValues.RetryDestination
     $env:RADIA_IDE_SMOKE_NATURAL_VCL_ROOT = $previousValues.Root
     $env:RADIA_IDE_SMOKE_DELPHI_VERSION = $previousValues.DelphiVersion
     $env:RADIA_IDE_SMOKE_TARGET_PLATFORM = $previousValues.Platform
@@ -74,6 +82,9 @@ $passed =
     $evidence.projectOpened -eq $true -and
     $evidence.buildPassed -eq $true -and
     $evidence.applicationStarted -eq $true -and
+    $evidence.destinationRecovered -eq $true -and
+    $evidence.requirementsPreserved -eq $true -and
+    $evidence.nativeOrchestration -eq $true -and
     $evidence.cliCompletedEarly -eq $false -and
     $evidence.toolUnavailable -eq $false -and
     (Test-Path -LiteralPath $projectFile -PathType Leaf)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # SonarQube Project Configuration
 sonar.projectKey=radia
 sonar.projectName=radia
-sonar.projectVersion=2.17.5
+sonar.projectVersion=2.17.6
 
 # Path to the source directories
 sonar.sources=Source


### PR DESCRIPTION
## Resumo

- preserva requisitos e troca corretamente o destino após conflito de pasta
- mantém a orquestração nativa e não perde aprovações durante a retomada
- evita encerramento prematuro e repetição improdutiva de ferramentas
- adiciona cobertura unitária, web e E2E para criação de calculadora VCL com histórico

## Validação

- 1.414 testes DUnitX no Delphi 12, sem falhas ou vazamentos
- 1.414 testes DUnitX no Delphi 13, sem falhas ou vazamentos
- 211 testes web
- matriz E2E crítica de release
- SonarQube Quality Gate aprovado, sem issues