### PR TITLE
Corrige a retomada visível da criação de projetos

### DIFF
--- a/RadIA.dproj
+++ b/RadIA.dproj
@@ -65,7 +65,7 @@
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.6.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.6.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.7.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.7.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     </PropertyGroup>
@@ -73,14 +73,14 @@
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.6.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.6.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.7.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.7.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64x)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.6.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.6.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.7.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.7.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <BCC_EnableBatchCompilation>true</BCC_EnableBatchCompilation>
     </PropertyGroup>

--- a/RadIA.rc
+++ b/RadIA.rc
@@ -17,12 +17,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Rad IA Open Source Project\0"
             VALUE "FileDescription", "Rad IA - AI Assistant for Delphi IDE\0"
-            VALUE "FileVersion", "2.17.6.0\0"
+            VALUE "FileVersion", "2.17.7.0\0"
             VALUE "InternalName", "RadIA\0"
             VALUE "LegalCopyright", "Copyright (c) 2026\0"
             VALUE "OriginalFilename", "RadIA.bpl\0"
             VALUE "ProductName", "Rad IA\0"
-            VALUE "ProductVersion", "2.17.6.0\0"
+            VALUE "ProductVersion", "2.17.7.0\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/Source/Core/RadIA.Core.Version.pas
+++ b/Source/Core/RadIA.Core.Version.pas
@@ -3,7 +3,7 @@ unit RadIA.Core.Version;
 interface
 
 const
-  CRadIAVersion = '2.17.6';
+  CRadIAVersion = '2.17.7';
 
 function RadIAVersionedCaption(const ACaption: string): string;
 

--- a/Source/UI/RadIA.UI.ChatFrame.pas
+++ b/Source/UI/RadIA.UI.ChatFrame.pas
@@ -85,6 +85,7 @@ type
     FAgentBudgetSmokeEvidencePath: string;
     FAgentBudgetSmokeStarted: Boolean;
     FNaturalVclSmokeEvidencePath: string;
+    FNaturalVclRecoveryVisible: Boolean;
     FNaturalVclSmokeStarted: Boolean;
     FSessionIsolationSmokeEvidencePath: string;
     FSessionIsolationSmokeStarted: Boolean;
@@ -820,6 +821,7 @@ begin
     GetEnvironmentVariable('RADIA_IDE_SMOKE_NATURAL_VCL')
   );
   FNaturalVclSmokeStarted := False;
+  FNaturalVclRecoveryVisible := False;
   FSessionIsolationSmokeEvidencePath := Trim(
     GetEnvironmentVariable('RADIA_IDE_SMOKE_SESSION_ISOLATION')
   );
@@ -1400,6 +1402,14 @@ begin
     if not (LJson is TJSONObject) then
       Exit;
     LRoot := TJSONObject(LJson);
+    if SameText(
+      LRoot.GetValue<string>('action', ''),
+      'natural_vcl_recovery_visible'
+    ) then
+    begin
+      FNaturalVclRecoveryVisible := True;
+      Exit(True);
+    end;
     if not SameText(
       LRoot.GetValue<string>('action', ''),
       'webview_lifecycle_state'
@@ -1895,6 +1905,7 @@ begin
       LRoot.GetValue<Boolean>('buildPassed', False) and
       LRoot.GetValue<Boolean>('applicationStarted', False) and
       LRoot.GetValue<Boolean>('destinationRecovered', False) and
+      FNaturalVclRecoveryVisible and
       LRoot.GetValue<Boolean>('requirementsPreserved', False) and
       LRoot.GetValue<Boolean>('nativeOrchestration', False) and
       not LRoot.GetValue<Boolean>('cliCompletedEarly', True) and
@@ -1935,6 +1946,10 @@ begin
       LEvidence.AddPair(
         'destinationRecovered',
         TJSONBool.Create(LRoot.GetValue<Boolean>('destinationRecovered', False))
+      );
+      LEvidence.AddPair(
+        'recoveryCardVisible',
+        TJSONBool.Create(FNaturalVclRecoveryVisible)
       );
       LEvidence.AddPair(
         'requirementsPreserved',
@@ -1984,7 +1999,10 @@ begin
     Exit;
   if FNaturalVclSmokeStarted then
   begin
-    FEdgeBrowser.ExecuteScript('resumeNaturalVclSmoke(300000);');
+    FEdgeBrowser.ExecuteScript(
+      'resumeNaturalVclSmoke(300000, ' +
+      LowerCase(BoolToStr(FNaturalVclRecoveryVisible, True)) + ');'
+    );
     Exit;
   end;
   FNaturalVclSmokeStarted := True;

--- a/Source/UI/RadIA.UI.ChatPresenter.pas
+++ b/Source/UI/RadIA.UI.ChatPresenter.pas
@@ -3734,6 +3734,12 @@ begin
   else
     LObjective := FPendingJourneyDeclarativePrompt + sLineBreak + sLineBreak +
       'User-provided context: ' + FPendingJourneyContext;
+  if SameText(FPendingJourneyField, 'destination') then
+    PostToWebView(
+      'add_message',
+      'assistant',
+      'New destination received. Preparing the recovered project plan.'
+    );
   ResetPendingJourney;
   if not FAgentModeEnabled then
     SetAgentModeEnabled(True);

--- a/Source/UI/Web/chat.js
+++ b/Source/UI/Web/chat.js
@@ -1187,7 +1187,17 @@ function renderAgentState(data) {
 
   const sessionId = state.sessionId || 'active';
   let card = AGENT_CARDS.get(sessionId);
-  if (!card) {
+  const status = state.status || 'unknown';
+  if (card) {
+    const previousStatus = card.dataset.status || '';
+    const previousRunFinished = ['completed', 'cancelled', 'failed']
+      .includes(previousStatus);
+    const recoveredRunStarted = !['completed', 'cancelled', 'failed']
+      .includes(status);
+    if (previousRunFinished && recoveredRunStarted) {
+      chatContainer.appendChild(card);
+    }
+  } else {
     card = document.createElement('section');
     card.className = 'agent-run-card';
     card.innerHTML =
@@ -1212,7 +1222,6 @@ function renderAgentState(data) {
     chatContainer.appendChild(card);
   }
 
-  const status = state.status || 'unknown';
   card.dataset.status = status;
   card.querySelector('.agent-run-status').textContent = status;
   card.querySelector('.agent-run-objective').textContent = state.objective || '';
@@ -3322,6 +3331,7 @@ function finishNaturalVclSmoke(status, reason = '', state = {}) {
     buildPassed: succeeded('BuildProject'),
     applicationStarted: succeeded('StartDebugging'),
     destinationRecovered: naturalVclSmoke.destinationRetried,
+    recoveryCardVisible: naturalVclSmoke.recoveryCardVisible,
     requirementsPreserved:
       String(state.objective || '').includes('operationHistory'),
     nativeOrchestration: naturalVclSmoke.nativeOrchestrationObserved,
@@ -3419,6 +3429,11 @@ function continueNaturalVclSmoke(card, state) {
   );
   if (retryObjectiveActive) {
     naturalVclSmoke.recoveryPending = false;
+    naturalVclSmoke.recoveryCardVisible =
+      card === chatContainer.lastElementChild;
+    if (naturalVclSmoke.recoveryCardVisible) {
+      postMessageToDelphi({ action: 'natural_vcl_recovery_visible' });
+    }
   }
   if (naturalVclSmoke.destinationRetried &&
       (!retryObjectiveActive || !retryPreviewActive) &&
@@ -3442,6 +3457,7 @@ globalThis.beginNaturalVclSmoke = function beginNaturalVclSmoke(
     planApproved: false,
     pendingApproval: null,
     recoveryPending: false,
+    recoveryCardVisible: false,
     recoveryRequestReady: false,
     recoveryStateObserved: false,
     retryDestination: String(retryDestination),
@@ -3456,7 +3472,8 @@ globalThis.beginNaturalVclSmoke = function beginNaturalVclSmoke(
 };
 
 globalThis.resumeNaturalVclSmoke = function resumeNaturalVclSmoke(
-  timeoutMilliseconds = 300000
+  timeoutMilliseconds = 300000,
+  recoveryCardVisible = false
 ) {
   if (naturalVclSmoke) return;
   naturalVclSmoke = {
@@ -3467,6 +3484,7 @@ globalThis.resumeNaturalVclSmoke = function resumeNaturalVclSmoke(
     planApproved: true,
     pendingApproval: null,
     recoveryPending: false,
+    recoveryCardVisible: Boolean(recoveryCardVisible),
     recoveryRequestReady: true,
     recoveryStateObserved: true,
     retryDestination: '',

--- a/Tests/Web/RadIA.ConversationE2E.test.js
+++ b/Tests/Web/RadIA.ConversationE2E.test.js
@@ -98,11 +98,15 @@ test('natural VCL smoke accepts the real route and requires complete evidence', 
   assert.match(chatScript, /retryPreviewActive/u);
   assert.match(chatScript, /destinationRetried &&/u);
   assert.match(chatScript, /destinationRecovered/u);
+  assert.match(chatScript, /recoveryCardVisible/u);
+  assert.match(chatScript, /previousRunFinished/u);
+  assert.match(chatScript, /chatContainer\.appendChild\(card\)/u);
   assert.match(chatScript, /requirementsPreserved/u);
   assert.match(chatScript, /nativeOrchestration/u);
   assert.match(chatScript, /CLI task completed\./u);
   assert.match(chatFrame, /RADIA_IDE_SMOKE_NATURAL_VCL_RETRY_DESTINATION/u);
   assert.match(presenter, /journey_input_requested/u);
+  assert.match(presenter, /New destination received\. Preparing the recovered project plan\./u);
   assert.match(presenter, /FActiveJourneyContext := LContext/u);
   assert.match(presenter, /FActiveJourneyDefinition := LDefinition/u);
   assert.match(presenter, /FActiveJourneyNative := True/u);

--- a/docs/guides/mcp_integration_guide.en.md
+++ b/docs/guides/mcp_integration_guide.en.md
@@ -195,7 +195,7 @@ For reproducible automation, prefer `mcp.<pid>.json`.
 1. Open Delphi and a project.
 2. Confirm that `mcp.<pid>.json` exists.
 3. Start or reload the MCP server in the client.
-4. Verify that `initialize` reports RadIA `2.17.6`.
+4. Verify that `initialize` reports RadIA `2.17.7`.
 5. Call `tools/list`.
 6. Call `GetIDEState` and `GetActiveProject`.
 7. Test mutable consent only in a disposable project.

--- a/docs/guides/mcp_integration_guide.md
+++ b/docs/guides/mcp_integration_guide.md
@@ -215,7 +215,7 @@ Para automação reproduzível, prefira sempre `mcp.<pid>.json`.
 1. Abra o Delphi e um projeto.
 2. Confirme que `mcp.<pid>.json` foi criado.
 3. Inicie ou recarregue o servidor no cliente MCP.
-4. Verifique que `initialize` retorna RadIA `2.17.6`.
+4. Verifique que `initialize` retorna RadIA `2.17.7`.
 5. Execute `tools/list`.
 6. Chame `GetIDEState` e `GetActiveProject`.
 7. Para testar consentimento, use uma tool mutável somente em um projeto descartável.

--- a/docs/guides/user_guide_journeys.en.md
+++ b/docs/guides/user_guide_journeys.en.md
@@ -82,7 +82,9 @@ alone does not satisfy this request.
 If the destination directory already exists, the run reports the conflict and keeps the journey waiting
 for another destination. The next reply replaces only the path: project type, platform, name, and
 functional requirements — including history — remain in the objective. The recommendation card is
-visibly consumed on the first click so it does not suggest that the same action is still available.
+visibly consumed on the first click so it does not suggest that the same action is still available. When
+the new path arrives, chat immediately confirms recovery and moves the recovered plan to the end of the
+conversation, where its new approval remains visible.
 
 ## Execution model
 

--- a/docs/guides/user_guide_journeys.md
+++ b/docs/guides/user_guide_journeys.md
@@ -82,7 +82,9 @@ não atende esse pedido.
 Se a pasta de destino já existir, a execução informa o conflito e mantém a jornada aguardando outro
 destino. A resposta seguinte substitui somente o caminho: tipo do projeto, plataforma, nome e requisitos
 funcionais — inclusive o histórico — continuam no objetivo. O cartão de recomendação é consumido
-visualmente no primeiro clique para não sugerir que a mesma ação ainda está disponível.
+visualmente no primeiro clique para não sugerir que a mesma ação ainda está disponível. Ao receber o
+novo caminho, o chat confirma imediatamente a retomada e move o plano recuperado para o final da
+conversa, onde a nova aprovação permanece visível.
 
 ## Como a execução funciona
 

--- a/docs/guides/user_manual.en.md
+++ b/docs/guides/user_manual.en.md
@@ -1,4 +1,4 @@
-# Complete RadIA 2.17.6 user manual
+# Complete RadIA 2.17.7 user manual
 
 > Use `/help` to compare Chat, Agent, CLI, and MCP. When a plan awaits approval, select
 > **Approve plan** or type `/agent resume`.
@@ -36,7 +36,7 @@ layouts such as `Startup Layout` and `Debug Layout`. If the panel is closed befo
 remains closed in the next session; use `Tools > RadIA > Chat` to open it again.
 
 The chat panel caption and primary RadIA windows show the loaded version, for example
-`Rad IA Chat v2.17.6`, so support can confirm the installed build quickly.
+`Rad IA Chat v2.17.7`, so support can confirm the installed build quickly.
 
 Supported credentials are protected locally with Windows DPAPI. Ollama and LM Studio can run
 locally. See the [installation guide](../getting-started/install_config.en.md).

--- a/docs/guides/user_manual.md
+++ b/docs/guides/user_manual.md
@@ -1,4 +1,4 @@
-# Manual completo do RadIA 2.17.6
+# Manual completo do RadIA 2.17.7
 
 > Para comparar Chat, Agent, CLI e MCP, use `/help`. Quando um plano aguardar aprovação, clique em
 > **Approve plan** ou digite `/agent resume`.
@@ -45,7 +45,7 @@ troca entre layouts nomeados, como `Startup Layout` e `Debug Layout`. Se o paine
 de sair, ele permanece fechado na sessão seguinte; use `Tools > RadIA > Chat` para abri-lo novamente.
 
 O caption do painel de chat e das janelas principais do RadIA mostra a versão carregada, por exemplo
-`Rad IA Chat v2.17.6`, para facilitar suporte e conferência de instalação.
+`Rad IA Chat v2.17.7`, para facilitar suporte e conferência de instalação.
 
 Se o painel ou package não aparecer:
 

--- a/docs/reference/cli_capability_matrix.en.md
+++ b/docs/reference/cli_capability_matrix.en.md
@@ -15,7 +15,7 @@
 
 ## Current matrix
 
-| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.6 use |
+| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.7 use |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Yes, JSONL | Structured event | `exec resume <id>` | Yes | Yes | Not declared | New execution per message |
 | Claude Code | Yes, stream JSON | Structured event | `--resume <id>` | Yes | Yes | Not declared | New execution per message |

--- a/docs/reference/cli_capability_matrix.md
+++ b/docs/reference/cli_capability_matrix.md
@@ -15,7 +15,7 @@
 
 ## Matriz atual
 
-| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.6 |
+| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.7 |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Sim, JSONL | Evento estruturado | `exec resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |
 | Claude Code | Sim, stream JSON | Evento estruturado | `--resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radia-plugin",
-  "version": "2.17.6",
+  "version": "2.17.7",
   "description": "Rad IA - AI Assistant for Delphi IDE",
   "main": "eslint.config.js",
   "scripts": {

--- a/scripts/Test-RadIA.NaturalVclChatE2E.ps1
+++ b/scripts/Test-RadIA.NaturalVclChatE2E.ps1
@@ -83,6 +83,7 @@ $passed =
     $evidence.buildPassed -eq $true -and
     $evidence.applicationStarted -eq $true -and
     $evidence.destinationRecovered -eq $true -and
+    $evidence.recoveryCardVisible -eq $true -and
     $evidence.requirementsPreserved -eq $true -and
     $evidence.nativeOrchestration -eq $true -and
     $evidence.cliCompletedEarly -eq $false -and

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # SonarQube Project Configuration
 sonar.projectKey=radia
 sonar.projectName=radia
-sonar.projectVersion=2.17.6
+sonar.projectVersion=2.17.7
 
 # Path to the source directories
 sonar.sources=Source


### PR DESCRIPTION
## Resumo\n\n- torna visível a retomada após informar um novo diretório\n- reposiciona o plano recuperado no fim da conversa\n- preserva a evidência durante a recarga do WebView\n- adiciona cobertura E2E do fluxo real\n- prepara a versão 2.17.7\n\n## Validação\n\n- ESLint\n- 211 testes web\n- 45 testes documentais\n- 1.414 testes Delphi 12, sem vazamentos\n- build Delphi 13\n- E2E real de criação VCL com conflito e retomada\n- SonarQube aprovado