### PR TITLE
Torna a execução de projetos opcional

### DIFF
--- a/RadIA.dproj
+++ b/RadIA.dproj
@@ -65,7 +65,7 @@
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.7.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.7.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.8.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.8.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     </PropertyGroup>
@@ -73,14 +73,14 @@
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.7.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.7.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.8.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.8.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64x)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.7.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.7.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.8.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.8.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <BCC_EnableBatchCompilation>true</BCC_EnableBatchCompilation>
     </PropertyGroup>

--- a/RadIA.rc
+++ b/RadIA.rc
@@ -1,6 +1,6 @@
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,17,7,0
-PRODUCTVERSION 2,17,7,0
+FILEVERSION 2,17,8,0
+PRODUCTVERSION 2,17,8,0
 FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -17,12 +17,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Rad IA Open Source Project\0"
             VALUE "FileDescription", "Rad IA - AI Assistant for Delphi IDE\0"
-            VALUE "FileVersion", "2.17.7.0\0"
+            VALUE "FileVersion", "2.17.8.0\0"
             VALUE "InternalName", "RadIA\0"
             VALUE "LegalCopyright", "Copyright (c) 2026\0"
             VALUE "OriginalFilename", "RadIA.bpl\0"
             VALUE "ProductName", "Rad IA\0"
-            VALUE "ProductVersion", "2.17.7.0\0"
+            VALUE "ProductVersion", "2.17.8.0\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/Source/Core/RadIA.Core.AgentProvider.pas
+++ b/Source/Core/RadIA.Core.AgentProvider.pas
@@ -241,7 +241,11 @@ begin
     'remain subject to RadIA consent and audit policies. After any source, ' +
     'project, or Designer mutation, inspect structured diagnostics and run ' +
     'BuildProject. Never complete while CURRENT_STATE.validation.buildPassed ' +
-    'is false. When DUnitX tests are available, run RunDUnitXTests after a ' +
+    'is false. For project creation, treat a successful build as the default ' +
+    'final gate. Call StartDebugging or runtime scenario tools only when the ' +
+    'objective contains runtimeValidation="required". Keep a runtime failure ' +
+    'separate from successful build evidence. When DUnitX tests are available, ' +
+    'run RunDUnitXTests after a ' +
     'successful build. When an authoritative Delphi Code Coverage report is ' +
     'available, run GetCoverageSummary after tests. If build or tests fail, ' +
     'inspect their structured ' +

--- a/Source/Core/RadIA.Core.AgentRuntime.pas
+++ b/Source/Core/RadIA.Core.AgentRuntime.pas
@@ -468,6 +468,7 @@ type
     function IsMutationTool(const AToolName: string): Boolean;
     function HasSuccessfulToolStep(const AToolName: string): Boolean;
     function IsProjectCreationObjective: Boolean;
+    function ProjectCreationRequiresExecution: Boolean;
     function ResolveRiskName(const AToolName: string): string;
     function ExtractAffectedFiles(
       const AArgumentsJson: string;
@@ -2651,6 +2652,14 @@ begin
   );
 end;
 
+function TRadIAAgentRuntime.ProjectCreationRequiresExecution: Boolean;
+begin
+  Result := IsProjectCreationObjective and ContainsText(
+    FObjective,
+    'runtimeValidation="required"'
+  );
+end;
+
 function TRadIAAgentRuntime.ResolveRiskName(
   const AToolName: string
 ): string;
@@ -2899,14 +2908,14 @@ begin
       'the latest mutation.';
     Exit(False);
   end;
-  if IsProjectCreationObjective and not LValidation.ExecutionRun then
+  if ProjectCreationRequiresExecution and not LValidation.ExecutionRun then
   begin
     AMessage :=
       'Validation gate rejected completion: start the created application ' +
       'and record successful execution evidence.';
     Exit(False);
   end;
-  if IsProjectCreationObjective and not LValidation.ExecutionPassed then
+  if ProjectCreationRequiresExecution and not LValidation.ExecutionPassed then
   begin
     AMessage :=
       'Validation gate rejected completion: the created application did not ' +

--- a/Source/Core/RadIA.Core.Journeys.pas
+++ b/Source/Core/RadIA.Core.Journeys.pas
@@ -223,6 +223,24 @@ begin
   AppendCreateContextValue(Result, LLowerContext, 'project', LProjectName);
   AppendCreateContextValue(Result, LLowerContext, 'type', LProjectType);
   AppendCreateContextValue(Result, LLowerContext, 'platform', 'Win32');
+  if ContainsAnyText(
+    LLowerContext,
+    [
+      'run the application', 'execute the application',
+      'start the application', 'runtime validation',
+      'functional validation', 'execute o aplicativo',
+      'execute o projeto', 'rode o aplicativo', 'rode o projeto',
+      'inicie o aplicativo', 'inicie o projeto',
+      'validação runtime', 'validacao runtime',
+      'validação funcional', 'validacao funcional'
+    ]
+  ) then
+    AppendCreateContextValue(
+      Result,
+      LLowerContext,
+      'runtimeValidation',
+      'required'
+    );
   if ContainsAnyText(LLowerContext, ['calculadora', 'calculator']) and
     ContainsAnyText(
       LLowerContext,
@@ -520,10 +538,10 @@ begin
       'profile only after the user explicitly selects or requests those additions. ' +
       'When calculator context includes feature="operationHistory", preserve it with ' +
       'projectSpecification schemaVersion 2 and features.operationHistory enabled and clearAction true. ' +
-      'The preview, plan, completion criteria, generated files, and runtime evidence must all retain every ' +
+      'The preview, plan, completion criteria, and generated files must all retain every ' +
       'explicit functional feature from the user context. A successful build alone does not prove a requested ' +
-      'feature. For operation history, exercise two calculations, verify their ordered history entries, clear ' +
-      'the history, and verify that it is empty before completing. ' +
+      'feature. Inspect the generated structure and implementation for every requested feature before completing. ' +
+      'For operation history, verify the controls, event wiring, ordered-entry implementation, and clear action. ' +
       'With no active project, ' +
       'use the user-approved destination parent as authorizedRoot. Use OpenCreatedProject, ' +
       'ValidateCreatedProject, and IDE execution tools instead of invoking MSBuild from a CLI. ' +
@@ -532,8 +550,10 @@ begin
       'GetKnowledgeStatus and only request an indexed document when the status confirms that the ' +
       'project index is ready. Avoid repeating workspace inspection after the destination, project ' +
       'type, platform, and active IDE state are known. ' +
-      'For executable projects, start the application after a successful build, confirm its main ' +
-      'window, exercise the primary user scenario, and record the observed result. When the ' +
+      'A successful build is the default final gate for ordinary project creation. Do not start or debug the ' +
+      'application unless the user explicitly requests execution or functional runtime validation. If execution ' +
+      'is explicitly requested, keep build and runtime results separate: a runtime failure does not invalidate a ' +
+      'successful build, and the final report must state which validation was not completed. When the ' +
       'reviewed preview declares a companionTestExecutable, run that executable through ' +
       'RunDUnitXTests after the build and include its report in the completion evidence.',
       [
@@ -554,14 +574,14 @@ begin
         ),
         TRadIAJourneyPhase.Create(
           'Verify',
-          'Build the target, repair reviewed defects, run executable output, and test its primary scenario.',
-          'Provide build iterations, compiler messages, visible-window and functional-test evidence.'
+          'Build the target, repair reviewed defects, and inspect requested features in the generated structure.',
+          'Provide build iterations, compiler messages, and structural evidence for requested features.'
         )
       ],
       [
         'The requested project is open in the IDE.',
         'The selected target builds or a specific external blocker is proven.',
-        'Executable output starts and its primary user scenario passes, or a blocker is proven.',
+        'Requested features have structural evidence; runtime evidence is required only when explicitly requested.',
         'Architecture, usage, dependencies, and third-party provenance are documented when applicable.'
       ]
     ),

--- a/Source/Core/RadIA.Core.Version.pas
+++ b/Source/Core/RadIA.Core.Version.pas
@@ -3,7 +3,7 @@ unit RadIA.Core.Version;
 interface
 
 const
-  CRadIAVersion = '2.17.7';
+  CRadIAVersion = '2.17.8';
 
 function RadIAVersionedCaption(const ACaption: string): string;
 

--- a/Source/UI/RadIA.UI.ChatFrame.pas
+++ b/Source/UI/RadIA.UI.ChatFrame.pas
@@ -548,7 +548,7 @@ begin
     ACallback(
         '{"kind":"plan","message":"Create and validate the VCL project.",' +
         '"steps":[{"title":"Create project",' +
-        '"description":"Preview, create, open, build, and run"}]}',
+        '"description":"Preview, create, open, inspect, and build"}]}',
         '',
         False,
         TTokenUsage.Empty
@@ -623,16 +623,9 @@ begin
         False,
         TTokenUsage.Empty
       )
-    else if not AgentStateHasSuccessfulTool(APrompt, 'StartDebugging') then
-      ACallback(
-        '{"kind":"tool","tool":"StartDebugging","arguments":{}}',
-        '',
-        False,
-        TTokenUsage.Empty
-      )
     else
       ACallback(
-        '{"kind":"complete","message":"Project created, built, and started."}',
+        '{"kind":"complete","message":"Project created, inspected, and built."}',
         '',
         False,
         TTokenUsage.Empty

--- a/Source/UI/Web/chat.js
+++ b/Source/UI/Web/chat.js
@@ -3395,8 +3395,7 @@ function finishNaturalVclSmokeFromState(status, state, stateSteps) {
       'PreviewProjectTemplate',
       'CreateProjectFromTemplate',
       'OpenCreatedProject',
-      'BuildProject',
-      'StartDebugging'
+      'BuildProject'
     ];
     const complete = required.every(toolName => stateSteps.some(
       step => step.toolName === toolName && step.success === true

--- a/Tests/Source/RadIA.Tests.AgentRuntime.pas
+++ b/Tests/Source/RadIA.Tests.AgentRuntime.pas
@@ -164,6 +164,8 @@ type
     [Test]
     procedure TestProjectCreationRejectsCompletionBeforeRequiredJourney;
     [Test]
+    procedure TestProjectCreationRequiresExecutionOnlyWhenExplicit;
+    [Test]
     procedure TestValidationSnapshotIncludesBuildDUnitXAndCoverageEvidence;
     [Test]
     procedure TestFailedBuildRequiresCorrectionAndSuccessfulRebuild;
@@ -1738,8 +1740,7 @@ begin
     TRadIAAgentDecision.CallTool('CreateProjectFromTemplate', '{}'),
     TRadIAAgentDecision.CallTool('OpenCreatedProject', '{}'),
     TRadIAAgentDecision.CallTool('BuildProject', '{}'),
-    TRadIAAgentDecision.CallTool('StartDebugging', '{}'),
-    TRadIAAgentDecision.Complete('Project created and executed.')
+    TRadIAAgentDecision.Complete('Project created and built.')
   ]);
   LStore := TRadIAMemoryAgentCheckpointStore.Create;
   LRuntime := NewRuntime(LExecutor, LProvider, LStore);
@@ -1753,7 +1754,54 @@ begin
     Assert.AreEqual(asAwaitingApproval, LResult.Status);
     LResult := LRuntime.Resume('project-creation-gate-session');
     Assert.AreEqual(asCompleted, LResult.Status);
-    Assert.AreEqual('Project created and executed.', LResult.Message);
+    Assert.AreEqual('Project created and built.', LResult.Message);
+    Assert.AreEqual(4, LExecutorObject.CallCount);
+  finally
+    LRuntime.Free;
+  end;
+end;
+
+procedure TTestRadIAAgentRuntime.
+  TestProjectCreationRequiresExecutionOnlyWhenExplicit;
+var
+  LExecutor: IRadIAToolExecutor;
+  LExecutorObject: TRadIAMockAgentToolExecutor;
+  LProvider: IRadIAAgentDecisionProvider;
+  LResult: TRadIAAgentRunResult;
+  LRuntime: TRadIAAgentRuntime;
+  LStore: IRadIAAgentCheckpointStore;
+begin
+  LExecutorObject := TRadIAMockAgentToolExecutor.Create(
+    TRadIAToolResult.Succeeded('{"status":"succeeded"}')
+  );
+  LExecutor := LExecutorObject;
+  LProvider := TRadIAMockAgentDecisionProvider.Create([
+    TRadIAAgentDecision.Plan('Approve creation.', '[{"title":"Create"}]'),
+    TRadIAAgentDecision.CallTool('PreviewProjectTemplate', '{}'),
+    TRadIAAgentDecision.CallTool('CreateProjectFromTemplate', '{}'),
+    TRadIAAgentDecision.CallTool('OpenCreatedProject', '{}'),
+    TRadIAAgentDecision.CallTool('BuildProject', '{}'),
+    TRadIAAgentDecision.Complete('Build passed.'),
+    TRadIAAgentDecision.CallTool('StartDebugging', '{}'),
+    TRadIAAgentDecision.Complete('Project created, built, and executed.')
+  ]);
+  LStore := TRadIAMemoryAgentCheckpointStore.Create;
+  LRuntime := NewRuntime(LExecutor, LProvider, LStore);
+  try
+    LResult := LRuntime.Start(
+      'Create a Delphi project from the user requirements. ' +
+        'User-provided context: runtimeValidation="required"',
+      'explicit-runtime-gate-session',
+      '',
+      TRadIAAgentLimits.Default
+    );
+    Assert.AreEqual(asAwaitingApproval, LResult.Status);
+    LResult := LRuntime.Resume('explicit-runtime-gate-session');
+    Assert.AreEqual(asCompleted, LResult.Status);
+    Assert.AreEqual(
+      'Project created, built, and executed.',
+      LResult.Message
+    );
     Assert.AreEqual(5, LExecutorObject.CallCount);
   finally
     LRuntime.Free;

--- a/Tests/Source/RadIA.Tests.ChatPresenter.pas
+++ b/Tests/Source/RadIA.Tests.ChatPresenter.pas
@@ -1453,7 +1453,14 @@ begin
     'companionTestExecutable'
   );
   Assert.Contains(FMockView.PostedMessages.Text, 'RunDUnitXTests');
-  Assert.Contains(FMockView.PostedMessages.Text, 'start the application');
+  Assert.Contains(
+    FMockView.PostedMessages.Text,
+    'successful build is the default final gate'
+  );
+  Assert.DoesNotContain(
+    FMockView.PostedMessages.Text,
+    'runtimeValidation=\"required\"'
+  );
   Assert.Contains(
     FMockView.PostedMessages.Text,
     'destination=\"D:\\CalculatorAcceptance\"'

--- a/Tests/Source/RadIA.Tests.Journeys.pas
+++ b/Tests/Source/RadIA.Tests.Journeys.pas
@@ -30,9 +30,11 @@ type
     [Test]
     procedure CreateJourneyCollectsProjectDestinationAndPlatform;
     [Test]
-    procedure CreateJourneyRequiresRuntimeValidation;
+    procedure CreateJourneyUsesBuildAsDefaultFinalGate;
     [Test]
     procedure NaturalCreateContextExtractsDestinationNameAndDefaultPlatform;
+    [Test]
+    procedure NaturalCreateContextMarksExplicitRuntimeValidation;
     [Test]
     procedure NaturalCalculatorHistoryPreservesFunctionalFeature;
     [Test]
@@ -257,15 +259,16 @@ begin
   end;
 end;
 
-procedure TTestRadIAJourneys.CreateJourneyRequiresRuntimeValidation;
+procedure TTestRadIAJourneys.CreateJourneyUsesBuildAsDefaultFinalGate;
 var
   LDefinition: TRadIAJourneyDefinition;
 begin
   Assert.IsTrue(TRadIAJourneyCatalog.Find('/journey create', LDefinition));
-  Assert.Contains(LDefinition.Objective, 'start the application');
-  Assert.Contains(LDefinition.Objective, 'exercise the primary user scenario');
+  Assert.Contains(LDefinition.Objective, 'successful build is the default final gate');
+  Assert.Contains(LDefinition.Objective, 'unless the user explicitly requests execution');
+  Assert.Contains(LDefinition.Objective, 'runtime failure does not invalidate a successful build');
   Assert.AreEqual(NativeInt(4), Length(LDefinition.SuccessCriteria));
-  Assert.Contains(LDefinition.SuccessCriteria[2], 'primary user scenario passes');
+  Assert.Contains(LDefinition.SuccessCriteria[2], 'runtime evidence is required only when explicitly requested');
 end;
 
 procedure TTestRadIAJourneys.InfersProjectCreationFromNaturalLanguage;
@@ -384,8 +387,20 @@ begin
   Assert.Contains(LContext, 'project="calculadora"');
   Assert.Contains(LContext, 'type="VCL"');
   Assert.Contains(LContext, 'platform="Win32"');
+  Assert.DoesNotContain(LContext, 'runtimeValidation');
   Assert.IsTrue(TRadIAJourneyCatalog.Find('/journey create', LDefinition));
   Assert.IsFalse(LDefinition.NextRequiredInput(LContext, LField, LQuestion));
+end;
+
+procedure TTestRadIAJourneys.
+  NaturalCreateContextMarksExplicitRuntimeValidation;
+var
+  LContext: string;
+begin
+  LContext := TRadIAJourneyCatalog.NormalizeCreateContext(
+    'crie uma calculadora VCL e execute o aplicativo'
+  );
+  Assert.Contains(LContext, 'runtimeValidation="required"');
 end;
 
 procedure TTestRadIAJourneys.

--- a/Tests/Usage/release-promises.json
+++ b/Tests/Usage/release-promises.json
@@ -14,10 +14,14 @@
     },
     {
       "id": "natural-vcl-project-creation",
-      "publicStatement": "A natural-language request creates, opens, builds, and runs a working VCL application.",
+      "publicStatement": "A request creates, opens, inspects, and builds a VCL app without running it by default.",
       "priority": "critical",
       "maximumDurationSeconds": 300,
-      "expectedOutcomes": ["project-opened", "build-passed", "application-ran"],
+      "expectedOutcomes": [
+        "project-opened",
+        "build-passed",
+        "application-not-started-by-default"
+      ],
       "forbiddenOutcomes": ["step-limit-reached", "false-success-message"],
       "requiredTargets": ["delphi12-win32", "delphi13-win32", "delphi13-ide64"],
       "scenarioId": "natural-vcl-project-creation"

--- a/Tests/Usage/usage-matrix.json
+++ b/Tests/Usage/usage-matrix.json
@@ -274,7 +274,7 @@
         "native-orchestration-used",
         "project-opened",
         "build-passed",
-        "application-ran",
+        "application-not-started-by-default",
         "clean-shutdown"
       ],
       "requiredEvidence": [
@@ -285,8 +285,7 @@
         "previewSucceeded",
         "creationSucceeded",
         "projectOpened",
-        "buildPassed",
-        "applicationStarted"
+        "buildPassed"
       ]
     },
     {

--- a/Tests/Web/RadIA.ConversationE2E.test.js
+++ b/Tests/Web/RadIA.ConversationE2E.test.js
@@ -84,7 +84,12 @@ test('natural VCL smoke accepts the real route and requires complete evidence', 
   assert.match(chatScript, /CreateProjectFromTemplate/u);
   assert.match(chatScript, /OpenCreatedProject/u);
   assert.match(chatScript, /BuildProject/u);
-  assert.match(chatScript, /StartDebugging/u);
+  assert.match(chatScript, /applicationStarted: succeeded\('StartDebugging'\)/u);
+  assert.match(
+    chatScript,
+    /const required = \[[\s\S]*?'BuildProject'\s*\];/u
+  );
+  assert.match(chatFrame, /Project created, inspected, and built\./u);
   assert.match(chatScript, /completed-before-required-evidence/u);
   assert.match(chatScript, /failedTool: failedStep\.toolName/u);
   assert.match(chatScript, /agentMessage: state\.message/u);

--- a/docs/development/usage_test_matrix.en.md
+++ b/docs/development/usage_test_matrix.en.md
@@ -26,8 +26,9 @@ powershell.exe -ExecutionPolicy Bypass `
 ```
 
 VCL creation starts in the real chat composer, accepts the recommendation shown to the user, and requires
-structured evidence for preview, creation, opening, build, and execution. The journey fails on premature CLI
-completion, an unavailable tool, a missing project file, or any required step that was not executed.
+structured evidence for preview, creation, opening, structural requirement preservation, and build without
+starting the application by default. The journey fails on premature CLI completion, an unavailable tool, a
+missing project file, or any required step that was not executed.
 
 Session isolation also uses the real WebView: it leaves a recommendation pending in the previous
 conversation, creates another conversation, confirms that history was cleared, and requires rejection of
@@ -93,7 +94,9 @@ Use `-PlanOnly` first to inspect cost and combinations without opening Delphi.
 
 `natural-vcl-project-creation` deliberately starts with an existing directory. The scenario passes only
 when the simulated user supplies another destination, the original requirements remain in the objective,
-execution stays on the native orchestrator, and the project is created, opened, built, and started.
+execution stays on the native orchestrator, and the project is created, opened, and built without starting
+the application. This is the representative gate for the default experience. `calculator-history-fidelity`
+and `vcl-project-creation-lifecycle` request and validate functional execution in a controlled environment.
 
 The `targeted` profile uses the already installed build and never silently replaces a developer's IDE.
 Explicitly install the intended revision with `build.ps1 -Install` first. The `startup`, `release`, and

--- a/docs/development/usage_test_matrix.md
+++ b/docs/development/usage_test_matrix.md
@@ -99,7 +99,9 @@ seleção: UI usa `chat-window-state-persistence`; agente usa `agent-step-budget
 
 `natural-vcl-project-creation` começa deliberadamente com uma pasta já existente. O cenário só passa
 quando o usuário simulado informa outro destino, os requisitos originais permanecem no objetivo, a
-execução continua no orquestrador nativo e o projeto é criado, aberto, compilado e iniciado.
+execução continua no orquestrador nativo e o projeto é criado, aberto e compilado sem iniciar o aplicativo.
+Esse é o gate representativo da experiência padrão. `calculator-history-fidelity` e
+`vcl-project-creation-lifecycle` pedem e validam execução funcional em ambiente controlado.
 
 O perfil `targeted` usa o build já instalado e nunca troca silenciosamente a IDE do desenvolvedor. Instale
 explicitamente a revisão desejada com `build.ps1 -Install` antes de executá-lo. Os perfis `startup`,

--- a/docs/guides/mcp_integration_guide.en.md
+++ b/docs/guides/mcp_integration_guide.en.md
@@ -195,7 +195,7 @@ For reproducible automation, prefer `mcp.<pid>.json`.
 1. Open Delphi and a project.
 2. Confirm that `mcp.<pid>.json` exists.
 3. Start or reload the MCP server in the client.
-4. Verify that `initialize` reports RadIA `2.17.7`.
+4. Verify that `initialize` reports RadIA `2.17.8`.
 5. Call `tools/list`.
 6. Call `GetIDEState` and `GetActiveProject`.
 7. Test mutable consent only in a disposable project.

--- a/docs/guides/mcp_integration_guide.md
+++ b/docs/guides/mcp_integration_guide.md
@@ -215,7 +215,7 @@ Para automação reproduzível, prefira sempre `mcp.<pid>.json`.
 1. Abra o Delphi e um projeto.
 2. Confirme que `mcp.<pid>.json` foi criado.
 3. Inicie ou recarregue o servidor no cliente MCP.
-4. Verifique que `initialize` retorna RadIA `2.17.7`.
+4. Verifique que `initialize` retorna RadIA `2.17.8`.
 5. Execute `tools/list`.
 6. Chame `GetIDEState` e `GetActiveProject`.
 7. Para testar consentimento, use uma tool mutável somente em um projeto descartável.

--- a/docs/guides/user_guide_editor_generation.en.md
+++ b/docs/guides/user_guide_editor_generation.en.md
@@ -109,12 +109,13 @@ and platform — before showing the approval plan.
 > **Safe Project Generation:**
 > For security reasons and to avoid accidentally overwriting existing code, the selected folder for project generation **must be completely empty**. Rad IA will block the physical saving process if the chosen directory contains any files.
 
-5. **IDE loading and validation**: after writing the files, RadIA opens the `.dproj`, builds it through
-   Delphi, repairs errors within the approved boundaries, and runs executable projects. Completion
-   reports creation, build, visible-window, and functional-validation evidence.
+5. **IDE loading and validation**: after writing the files, RadIA opens the `.dproj`, structurally checks
+   the requirements, builds it through Delphi, and repairs errors within the approved boundaries. The
+   application starts only when the user explicitly requests execution or functional validation.
+   Completion distinguishes creation, build, and any runtime result.
 
 The external CLI does not need to find `msbuild` on `PATH` for this workflow. RadIA's native tools
-perform project creation, build, and execution. When a CLI assists the analysis, the chat displays
+perform project creation, build, and optional execution. When a CLI assists the analysis, the chat displays
 an expandable activity card with its current stage, elapsed time, and technical output.
 
 Project links open in the IDE. Web links open in the default browser and never replace the main chat

--- a/docs/guides/user_guide_editor_generation.md
+++ b/docs/guides/user_guide_editor_generation.md
@@ -109,12 +109,13 @@ pasta de destino e plataforma — antes de apresentar o plano para aprovação.
 > **Gravação Segura de Projetos:**
 > Por medidas de segurança e para evitar sobregravações acidentais de código existente, a pasta selecionada para a geração do projeto **deve estar totalmente vazia**. O Rad IA bloqueará o processo de gravação física no disco caso a pasta possua quaisquer outros arquivos.
 
-5. **Abertura e validação na IDE**: após a gravação, o RadIA abre o `.dproj`, compila pelo próprio
-   Delphi, corrige erros dentro dos limites aprovados e executa projetos que produzam aplicativo.
-   A conclusão informa evidências de criação, build, abertura da janela e validação funcional.
+5. **Abertura e validação na IDE**: após a gravação, o RadIA abre o `.dproj`, confere estruturalmente
+   os requisitos, compila pelo próprio Delphi e corrige erros dentro dos limites aprovados. O aplicativo
+   só é iniciado quando o usuário pede explicitamente execução ou validação funcional. A conclusão
+   distingue criação, build e eventual resultado runtime.
 
 O CLI externo não precisa localizar `msbuild` no `PATH` para esse fluxo. A criação, o build e a
-execução são conduzidos pelas ferramentas nativas do RadIA. Quando um CLI participa da análise, o
+execução opcional são conduzidos pelas ferramentas nativas do RadIA. Quando um CLI participa da análise, o
 chat mostra uma atividade expansível com etapa atual, tempo decorrido e saída técnica.
 
 Links de projeto abrem o arquivo na IDE. Links web são enviados ao navegador padrão e nunca

--- a/docs/guides/user_guide_journeys.en.md
+++ b/docs/guides/user_guide_journeys.en.md
@@ -30,8 +30,14 @@ The complete local classification contract and its safeguards are documented in
 [Intent routing](../reference/intent_routing.en.md).
 
 Every recipe has four required phases. Each phase defines the expected work and the evidence that
-must appear in the timeline. The run also receives three completion criteria, so the agent cannot
+must appear in the timeline. The run also receives completion criteria, so the agent cannot
 claim success merely because it produced a text response.
+
+For ordinary project creation, a successful build is the default final gate. RadIA opens the project,
+structurally checks the requested requirements, and builds it, but does not start or debug the application
+without an explicit user request. When execution is requested, its result is reported separately: a runtime
+failure does not turn a successful build into a compilation failure. Dedicated E2E tests continue to run
+applications in controlled environments to validate functional behavior.
 
 | Command | Objective |
 |---|---|

--- a/docs/guides/user_guide_journeys.md
+++ b/docs/guides/user_guide_journeys.md
@@ -30,8 +30,14 @@ O contrato completo da classificação local e suas proteções está em
 [Roteamento de intenção](../reference/intent_routing.md).
 
 Cada receita possui quatro fases obrigatórias. Cada fase define o trabalho esperado e a evidência
-que deve aparecer na timeline. A execução também recebe três critérios de conclusão; o agente não
+que deve aparecer na timeline. A execução também recebe critérios de conclusão; o agente não
 deve declarar sucesso apenas porque produziu uma resposta textual.
+
+Na criação comum de projetos, o build aprovado é o gate final padrão. O RadIA abre o projeto, confere
+estruturalmente os requisitos solicitados e compila, mas não inicia nem depura o aplicativo sem um pedido
+explícito do usuário. Quando a execução for solicitada, seu resultado é informado separadamente: uma falha
+runtime não transforma um build aprovado em falha de compilação. Testes E2E específicos continuam executando
+aplicativos em ambiente controlado para validar comportamento funcional.
 
 | Comando | Objetivo |
 |---|---|

--- a/docs/guides/user_manual.en.md
+++ b/docs/guides/user_manual.en.md
@@ -1,4 +1,4 @@
-# Complete RadIA 2.17.7 user manual
+# Complete RadIA 2.17.8 user manual
 
 > Use `/help` to compare Chat, Agent, CLI, and MCP. When a plan awaits approval, select
 > **Approve plan** or type `/agent resume`.
@@ -36,7 +36,7 @@ layouts such as `Startup Layout` and `Debug Layout`. If the panel is closed befo
 remains closed in the next session; use `Tools > RadIA > Chat` to open it again.
 
 The chat panel caption and primary RadIA windows show the loaded version, for example
-`Rad IA Chat v2.17.7`, so support can confirm the installed build quickly.
+`Rad IA Chat v2.17.8`, so support can confirm the installed build quickly.
 
 Supported credentials are protected locally with Windows DPAPI. Ollama and LM Studio can run
 locally. See the [installation guide](../getting-started/install_config.en.md).

--- a/docs/guides/user_manual.md
+++ b/docs/guides/user_manual.md
@@ -1,4 +1,4 @@
-# Manual completo do RadIA 2.17.7
+# Manual completo do RadIA 2.17.8
 
 > Para comparar Chat, Agent, CLI e MCP, use `/help`. Quando um plano aguardar aprovação, clique em
 > **Approve plan** ou digite `/agent resume`.
@@ -45,7 +45,7 @@ troca entre layouts nomeados, como `Startup Layout` e `Debug Layout`. Se o paine
 de sair, ele permanece fechado na sessão seguinte; use `Tools > RadIA > Chat` para abri-lo novamente.
 
 O caption do painel de chat e das janelas principais do RadIA mostra a versão carregada, por exemplo
-`Rad IA Chat v2.17.7`, para facilitar suporte e conferência de instalação.
+`Rad IA Chat v2.17.8`, para facilitar suporte e conferência de instalação.
 
 Se o painel ou package não aparecer:
 

--- a/docs/reference/cli_capability_matrix.en.md
+++ b/docs/reference/cli_capability_matrix.en.md
@@ -15,7 +15,7 @@
 
 ## Current matrix
 
-| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.7 use |
+| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.8 use |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Yes, JSONL | Structured event | `exec resume <id>` | Yes | Yes | Not declared | New execution per message |
 | Claude Code | Yes, stream JSON | Structured event | `--resume <id>` | Yes | Yes | Not declared | New execution per message |

--- a/docs/reference/cli_capability_matrix.md
+++ b/docs/reference/cli_capability_matrix.md
@@ -15,7 +15,7 @@
 
 ## Matriz atual
 
-| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.7 |
+| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.8 |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Sim, JSONL | Evento estruturado | `exec resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |
 | Claude Code | Sim, stream JSON | Evento estruturado | `--resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radia-plugin",
-  "version": "2.17.7",
+  "version": "2.17.8",
   "description": "Rad IA - AI Assistant for Delphi IDE",
   "main": "eslint.config.js",
   "scripts": {

--- a/scripts/Test-RadIA.NaturalVclChatE2E.ps1
+++ b/scripts/Test-RadIA.NaturalVclChatE2E.ps1
@@ -81,7 +81,7 @@ $passed =
     $evidence.creationSucceeded -eq $true -and
     $evidence.projectOpened -eq $true -and
     $evidence.buildPassed -eq $true -and
-    $evidence.applicationStarted -eq $true -and
+    $evidence.applicationStarted -eq $false -and
     $evidence.destinationRecovered -eq $true -and
     $evidence.recoveryCardVisible -eq $true -and
     $evidence.requirementsPreserved -eq $true -and

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # SonarQube Project Configuration
 sonar.projectKey=radia
 sonar.projectName=radia
-sonar.projectVersion=2.17.7
+sonar.projectVersion=2.17.8
 
 # Path to the source directories
 sonar.sources=Source


### PR DESCRIPTION
## Resumo\n\n- encerra a criação comum após inspeção estrutural e build aprovado\n- executa o aplicativo somente quando solicitado explicitamente\n- separa falha runtime de evidência de build\n- preserva E2E runtime específicos e altera o E2E padrão para provar que não há execução automática\n- prepara a versão 2.17.8\n\n## Validação\n\n- 1.416 testes Delphi e 8 testes externos aprovados, sem vazamentos\n- 211 testes web aprovados\n- 45 testes documentais aprovados\n- ESLint aprovado\n- builds Delphi 12 e 13 aprovados