### PR TITLE
Alinha o gate E2E da conclusão por build

### DIFF
--- a/Source/UI/RadIA.UI.ChatFrame.pas
+++ b/Source/UI/RadIA.UI.ChatFrame.pas
@@ -1896,7 +1896,7 @@ begin
       LRoot.GetValue<Boolean>('creationSucceeded', False) and
       LRoot.GetValue<Boolean>('projectOpened', False) and
       LRoot.GetValue<Boolean>('buildPassed', False) and
-      LRoot.GetValue<Boolean>('applicationStarted', False) and
+      not LRoot.GetValue<Boolean>('applicationStarted', True) and
       LRoot.GetValue<Boolean>('destinationRecovered', False) and
       FNaturalVclRecoveryVisible and
       LRoot.GetValue<Boolean>('requirementsPreserved', False) and

--- a/Tests/Web/RadIA.ConversationE2E.test.js
+++ b/Tests/Web/RadIA.ConversationE2E.test.js
@@ -90,6 +90,10 @@ test('natural VCL smoke accepts the real route and requires complete evidence', 
     /const required = \[[\s\S]*?'BuildProject'\s*\];/u
   );
   assert.match(chatFrame, /Project created, inspected, and built\./u);
+  assert.match(
+    chatFrame,
+    /not LRoot\.GetValue<Boolean>\('applicationStarted', True\)/u
+  );
   assert.match(chatScript, /completed-before-required-evidence/u);
   assert.match(chatScript, /failedTool: failedStep\.toolName/u);
   assert.match(chatScript, /agentMessage: state\.message/u);


### PR DESCRIPTION
Corrige o capturador Pascal do E2E para exigir que a criação padrão termine sem iniciar o aplicativo. O cenário real comprovou criação, abertura e build, mas o contrato residual ainda esperava applicationStarted=true.