### PR TITLE
Remove espera de processo do E2E padrão

### DIFF
--- a/Tests/Web/RadIA.ConversationE2E.test.js
+++ b/Tests/Web/RadIA.ConversationE2E.test.js
@@ -94,6 +94,7 @@ test('natural VCL smoke accepts the real route and requires complete evidence', 
     chatFrame,
     /not LRoot\.GetValue<Boolean>\('applicationStarted', True\)/u
   );
+  assert.doesNotMatch(naturalVclRunner, /UserJourneyExecutablePath/u);
   assert.match(chatScript, /completed-before-required-evidence/u);
   assert.match(chatScript, /failedTool: failedStep\.toolName/u);
   assert.match(chatScript, /agentMessage: state\.message/u);

--- a/scripts/Test-RadIA.NaturalVclChatE2E.ps1
+++ b/scripts/Test-RadIA.NaturalVclChatE2E.ps1
@@ -44,15 +44,10 @@ try {
     $env:RADIA_IDE_SMOKE_DELPHI_VERSION = $DelphiVersion
     $env:RADIA_IDE_SMOKE_TARGET_PLATFORM = if ($IDE64) { "Win64" } else { "Win32" }
     $env:RADIA_IDE_SMOKE_AUTO_CONSENT = "1"
-    $targetPlatform = $env:RADIA_IDE_SMOKE_TARGET_PLATFORM
-    $journeyExecutable = Join-Path $destination (
-        "bin\$targetPlatform\Debug\RadIAUserCalculator.exe"
-    )
     $arguments = @{
         DelphiVersion = $DelphiVersion
         Cycles = 1
         UserJourneyEvidencePath = $resolvedEvidence
-        UserJourneyExecutablePath = $journeyExecutable
     }
     if ($IDE64) {
         $arguments.IDE64 = $true


### PR DESCRIPTION
O cenário natural-vcl-project-creation agora valida criação, abertura e build sem fornecer um executável para observação. Cenários runtime separados continuam responsáveis por iniciar e validar aplicações.