### PR TITLE
Release RadIA 2.17.9

### DIFF
--- a/RadIA.dproj
+++ b/RadIA.dproj
@@ -65,7 +65,7 @@
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.8.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.8.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.9.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.9.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     </PropertyGroup>
@@ -73,14 +73,14 @@
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.8.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.8.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.9.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.9.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64x)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.8.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.8.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.9.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.9.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <BCC_EnableBatchCompilation>true</BCC_EnableBatchCompilation>
     </PropertyGroup>

--- a/RadIA.rc
+++ b/RadIA.rc
@@ -1,6 +1,6 @@
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,17,8,0
-PRODUCTVERSION 2,17,8,0
+FILEVERSION 2,17,9,0
+PRODUCTVERSION 2,17,9,0
 FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -17,12 +17,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Rad IA Open Source Project\0"
             VALUE "FileDescription", "Rad IA - AI Assistant for Delphi IDE\0"
-            VALUE "FileVersion", "2.17.8.0\0"
+            VALUE "FileVersion", "2.17.9.0\0"
             VALUE "InternalName", "RadIA\0"
             VALUE "LegalCopyright", "Copyright (c) 2026\0"
             VALUE "OriginalFilename", "RadIA.bpl\0"
             VALUE "ProductName", "Rad IA\0"
-            VALUE "ProductVersion", "2.17.8.0\0"
+            VALUE "ProductVersion", "2.17.9.0\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/Source/Core/RadIA.Core.Build.pas
+++ b/Source/Core/RadIA.Core.Build.pas
@@ -105,6 +105,9 @@ class function TRadIABuildResult.Completed(
   const ADurationMs: Int64;
   const AMessages: TArray<TRadIACompilerMessage>
 ): TRadIABuildResult;
+var
+  LMessage: TRadIACompilerMessage;
+  LMessageCount: Integer;
 begin
   Result.FSuccess := AStatus = bsSucceeded;
   Result.FStatus := AStatus;
@@ -112,7 +115,16 @@ begin
   Result.FConfiguration := AProject.Configuration;
   Result.FPlatform := AProject.Platform;
   Result.FDurationMs := ADurationMs;
-  Result.FMessages := Copy(AMessages);
+  SetLength(Result.FMessages, Length(AMessages));
+  LMessageCount := 0;
+  for LMessage in AMessages do
+  begin
+    if Result.FSuccess and (LMessage.Severity = cmsError) then
+      Continue;
+    Result.FMessages[LMessageCount] := LMessage;
+    Inc(LMessageCount);
+  end;
+  SetLength(Result.FMessages, LMessageCount);
   Result.FErrorCode := '';
   Result.FErrorMessage := '';
 end;

--- a/Source/Core/RadIA.Core.BuildTools.pas
+++ b/Source/Core/RadIA.Core.BuildTools.pas
@@ -210,7 +210,7 @@ begin
   Result := TRadIAToolDescriptor.Create(
     'BuildProject',
     '1.0.0',
-    'Builds the active project without running its output.',
+    'Builds the active project and returns diagnostics from this build only.',
     CBuildInputSchema,
     CBuildOutputSchema,
     trExecution

--- a/Source/Core/RadIA.Core.Version.pas
+++ b/Source/Core/RadIA.Core.Version.pas
@@ -3,7 +3,7 @@ unit RadIA.Core.Version;
 interface
 
 const
-  CRadIAVersion = '2.17.8';
+  CRadIAVersion = '2.17.9';
 
 function RadIAVersionedCaption(const ACaption: string): string;
 

--- a/Source/Integration/RadIA.OTA.Build.pas
+++ b/Source/Integration/RadIA.OTA.Build.pas
@@ -64,7 +64,8 @@ uses
   System.SysUtils,
   System.SyncObjs,
   ToolsAPI,
-  Winapi.Windows;
+  Winapi.Windows,
+  RadIA.Core.Logger;
 
 const
   CBuildBusy = 'build_busy';
@@ -314,6 +315,7 @@ var
   LExitCode: Cardinal;
   LIDERoot: string;
   LMessages: TArray<TRadIACompilerMessage>;
+  LMessageSource: string;
   LOutputPath: string;
   LPlatform: string;
   LProject: TRadIAProjectSnapshot;
@@ -390,6 +392,7 @@ begin
     if (LStatus = bsSucceeded) and (LExitCode <> 0) then
       LStatus := bsFailed;
     LMessages := ParseBuildMessages(LOutputPath);
+    LMessageSource := 'process-output';
     if (LStatus = bsFailed) and (Length(LMessages) = 0) then
     begin
       LCommandLine := ReadBuildFailureMessage(LOutputPath);
@@ -403,13 +406,28 @@ begin
           0,
           0
         );
+        LMessageSource := 'process-failure-output';
       end;
     end;
     System.SysUtils.DeleteFile(LOutputPath);
     if Length(LMessages) = 0 then
-      LMessages := FWorkspace.GetCompilerMessages(200);
+      LMessageSource := 'none';
     LStopwatch.Stop;
     SetStatus(LStatus);
+    TLogger.Log(
+      Format(
+        'Build completed: status=%d, exitCode=%d, messages=%d, ' +
+        'messageSource=%s, clearMessages=%s.',
+        [
+          Ord(LStatus),
+          LExitCode,
+          Length(LMessages),
+          LMessageSource,
+          BoolToStr(ARequest.ClearMessages, True)
+        ]
+      ),
+      'Build'
+    );
     Result := TRadIABuildResult.Completed(
       LStatus,
       LProject,

--- a/Tests/Source/RadIA.Tests.BuildTools.pas
+++ b/Tests/Source/RadIA.Tests.BuildTools.pas
@@ -56,6 +56,8 @@ type
     procedure StatusToolIsReadOnly;
     [Test]
     procedure CancelToolReturnsStructuredResult;
+    [Test]
+    procedure SuccessfulBuildExcludesErrorMessages;
   end;
 
 implementation
@@ -199,6 +201,47 @@ begin
   FBuildFacade.CurrentStatus := bsRunning;
   LResult := ExecuteTool('GetBuildStatus', '{}');
   Assert.Contains(LResult.ContentJson, '"status":"running"');
+end;
+
+procedure TTestRadIABuildTools.SuccessfulBuildExcludesErrorMessages;
+var
+  LProject: TRadIAProjectSnapshot;
+  LResult: TRadIAToolResult;
+begin
+  LProject := TRadIAProjectSnapshot.Create(
+    'ProjectOne',
+    'C:\Project\ProjectOne.dproj',
+    'C:\Project',
+    'Debug',
+    'Win32'
+  );
+  FBuildFacade.BuildResult := TRadIABuildResult.Completed(
+    bsSucceeded,
+    LProject,
+    250,
+    [
+      TRadIACompilerMessage.Create(
+        cmsError,
+        'F1027 Unit not found: System',
+        'MainForm.pas',
+        1,
+        0
+      ),
+      TRadIACompilerMessage.Create(
+        cmsWarning,
+        'W1000 Symbol deprecated',
+        'MainForm.pas',
+        2,
+        0
+      )
+    ]
+  );
+
+  LResult := ExecuteTool('BuildProject', '{}');
+
+  Assert.IsTrue(LResult.Success);
+  Assert.Contains(LResult.ContentJson, 'W1000 Symbol deprecated');
+  Assert.IsFalse(LResult.ContentJson.Contains('F1027'));
 end;
 
 initialization

--- a/docs/guides/mcp_integration_guide.en.md
+++ b/docs/guides/mcp_integration_guide.en.md
@@ -195,7 +195,7 @@ For reproducible automation, prefer `mcp.<pid>.json`.
 1. Open Delphi and a project.
 2. Confirm that `mcp.<pid>.json` exists.
 3. Start or reload the MCP server in the client.
-4. Verify that `initialize` reports RadIA `2.17.8`.
+4. Verify that `initialize` reports RadIA `2.17.9`.
 5. Call `tools/list`.
 6. Call `GetIDEState` and `GetActiveProject`.
 7. Test mutable consent only in a disposable project.

--- a/docs/guides/mcp_integration_guide.md
+++ b/docs/guides/mcp_integration_guide.md
@@ -215,7 +215,7 @@ Para automação reproduzível, prefira sempre `mcp.<pid>.json`.
 1. Abra o Delphi e um projeto.
 2. Confirme que `mcp.<pid>.json` foi criado.
 3. Inicie ou recarregue o servidor no cliente MCP.
-4. Verifique que `initialize` retorna RadIA `2.17.8`.
+4. Verifique que `initialize` retorna RadIA `2.17.9`.
 5. Execute `tools/list`.
 6. Chame `GetIDEState` e `GetActiveProject`.
 7. Para testar consentimento, use uma tool mutável somente em um projeto descartável.

--- a/docs/guides/user_manual.en.md
+++ b/docs/guides/user_manual.en.md
@@ -1,4 +1,4 @@
-# Complete RadIA 2.17.8 user manual
+# Complete RadIA 2.17.9 user manual
 
 > Use `/help` to compare Chat, Agent, CLI, and MCP. When a plan awaits approval, select
 > **Approve plan** or type `/agent resume`.
@@ -36,7 +36,7 @@ layouts such as `Startup Layout` and `Debug Layout`. If the panel is closed befo
 remains closed in the next session; use `Tools > RadIA > Chat` to open it again.
 
 The chat panel caption and primary RadIA windows show the loaded version, for example
-`Rad IA Chat v2.17.8`, so support can confirm the installed build quickly.
+`Rad IA Chat v2.17.9`, so support can confirm the installed build quickly.
 
 Supported credentials are protected locally with Windows DPAPI. Ollama and LM Studio can run
 locally. See the [installation guide](../getting-started/install_config.en.md).
@@ -357,7 +357,8 @@ See the [agentic tools guide](user_guide_agentic_tools.en.md).
 
 ### 4.6 Build
 
-`BuildProject` supports `make`, `build`, `check`, and `clean`. `GetBuildStatus`, `CancelBuild`, and
+`BuildProject` supports `make`, `build`, `check`, and `clean`, and returns messages from the current
+build only. `GetBuildStatus`, `CancelBuild`, and
 `GetCompilerMessages` expose controlled execution and structured output. A build does not grant
 permission to run its binary.
 

--- a/docs/guides/user_manual.md
+++ b/docs/guides/user_manual.md
@@ -1,4 +1,4 @@
-# Manual completo do RadIA 2.17.8
+# Manual completo do RadIA 2.17.9
 
 > Para comparar Chat, Agent, CLI e MCP, use `/help`. Quando um plano aguardar aprovação, clique em
 > **Approve plan** ou digite `/agent resume`.
@@ -45,7 +45,7 @@ troca entre layouts nomeados, como `Startup Layout` e `Debug Layout`. Se o paine
 de sair, ele permanece fechado na sessão seguinte; use `Tools > RadIA > Chat` para abri-lo novamente.
 
 O caption do painel de chat e das janelas principais do RadIA mostra a versão carregada, por exemplo
-`Rad IA Chat v2.17.8`, para facilitar suporte e conferência de instalação.
+`Rad IA Chat v2.17.9`, para facilitar suporte e conferência de instalação.
 
 Se o painel ou package não aparecer:
 
@@ -452,7 +452,7 @@ Consulte o [guia de ferramentas agentivas](user_guide_agentic_tools.md).
 
 ### 4.7 Build
 
-- `BuildProject`: modos `make`, `build`, `check` e `clean`.
+- `BuildProject`: modos `make`, `build`, `check` e `clean`; as mensagens retornadas pertencem somente ao build atual.
 - `GetBuildStatus`: estado do build controlado.
 - `CancelBuild`: cancelamento cooperativo.
 - `GetCompilerMessages`: erros e warnings estruturados.

--- a/docs/reference/cli_capability_matrix.en.md
+++ b/docs/reference/cli_capability_matrix.en.md
@@ -15,7 +15,7 @@
 
 ## Current matrix
 
-| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.8 use |
+| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.9 use |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Yes, JSONL | Structured event | `exec resume <id>` | Yes | Yes | Not declared | New execution per message |
 | Claude Code | Yes, stream JSON | Structured event | `--resume <id>` | Yes | Yes | Not declared | New execution per message |

--- a/docs/reference/cli_capability_matrix.md
+++ b/docs/reference/cli_capability_matrix.md
@@ -15,7 +15,7 @@
 
 ## Matriz atual
 
-| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.8 |
+| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.9 |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Sim, JSONL | Evento estruturado | `exec resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |
 | Claude Code | Sim, stream JSON | Evento estruturado | `--resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |

--- a/docs/reference/internal_tools_reference.en.md
+++ b/docs/reference/internal_tools_reference.en.md
@@ -297,7 +297,7 @@ passes `execution` classification and does not accept arbitrary names received f
 
 |Tool|What it does|When it is triggered|
 |---|---|---|
-|`BuildProject`|Runs `make`, `build`, `check`, or `clean` with structured diagnostics.|To validate changes, reproduce errors, or meet the build gate.|
+|`BuildProject`|Runs `make`, `build`, `check`, or `clean` with diagnostics from the current execution only.|To validate changes, reproduce errors, or meet the build gate.|
 |`CancelBuild`|Requests co-op cancellation of the active build.|By the cancel button, by the agent or when a timeout is reached.|
 |`GetBuildStatus`|Returns state, duration and result of the controlled build.|While the agent tracks the build or before starting another.|
 

--- a/docs/reference/internal_tools_reference.md
+++ b/docs/reference/internal_tools_reference.md
@@ -297,7 +297,7 @@ passa pela classificação `execution` e não aceita nomes arbitrários recebido
 
 | Ferramenta | O que faz | Quando é acionada |
 |---|---|---|
-| `BuildProject` | Executa `make`, `build`, `check` ou `clean` com diagnóstico estruturado. | Para validar mudanças, reproduzir erros ou cumprir o gate de build. |
+| `BuildProject` | Executa `make`, `build`, `check` ou `clean` com diagnósticos exclusivos da execução atual. | Para validar mudanças, reproduzir erros ou cumprir o gate de build. |
 | `CancelBuild` | Solicita o cancelamento cooperativo do build ativo. | Pelo botão de cancelamento, pelo agente ou quando um timeout é atingido. |
 | `GetBuildStatus` | Retorna estado, duração e resultado do build controlado. | Enquanto o agente acompanha a compilação ou antes de iniciar outra. |
 

--- a/docs/reference/runtime_tool_catalog.en.md
+++ b/docs/reference/runtime_tool_catalog.en.md
@@ -249,7 +249,7 @@ This list contains only the built-in tools registered by the current package. Ar
 
 | Tool | Purpose | Source unit |
 |---|---|---|
-| `BuildProject` | Builds the active project without running its output. | `RadIA.Core.BuildTools.pas` |
+| `BuildProject` | Builds the active project and returns diagnostics from this build only. | `RadIA.Core.BuildTools.pas` |
 | `CancelBuild` | Requests cancellation of the active background build. | `RadIA.Core.BuildTools.pas` |
 | `GetBuildStatus` | Returns the current or most recent build status. | `RadIA.Core.BuildTools.pas` |
 

--- a/docs/reference/runtime_tool_catalog.md
+++ b/docs/reference/runtime_tool_catalog.md
@@ -249,7 +249,7 @@ Esta lista contém somente as ferramentas internas registradas pelo pacote atual
 
 | Ferramenta | O que faz | Unit de origem |
 |---|---|---|
-| `BuildProject` | Executa `make`, `build`, `check` ou `clean` com diagnóstico estruturado. | `RadIA.Core.BuildTools.pas` |
+| `BuildProject` | Executa `make`, `build`, `check` ou `clean` com diagnósticos exclusivos da execução atual. | `RadIA.Core.BuildTools.pas` |
 | `CancelBuild` | Solicita o cancelamento cooperativo do build ativo. | `RadIA.Core.BuildTools.pas` |
 | `GetBuildStatus` | Retorna estado, duração e resultado do build controlado. | `RadIA.Core.BuildTools.pas` |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radia-plugin",
-  "version": "2.17.8",
+  "version": "2.17.9",
   "description": "Rad IA - AI Assistant for Delphi IDE",
   "main": "eslint.config.js",
   "scripts": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # SonarQube Project Configuration
 sonar.projectKey=radia
 sonar.projectName=radia
-sonar.projectVersion=2.17.8
+sonar.projectVersion=2.17.9
 
 # Path to the source directories
 sonar.sources=Source


### PR DESCRIPTION
## Summary
- prevent stale IDE compiler diagnostics from contaminating successful external builds
- enforce successful-build message invariants and add audit logging
- update documentation, catalogs, tests, and version to 2.17.9

## Validation
- Delphi 12 and 13 complete DUnitX suites passed (1425/1425 each, no leaks)
- startup matrix passed for Delphi 12 Win32, Delphi 13 Win32, and Delphi 13 IDE64
- release-critical usage matrix passed 9/9 on Delphi 13 Win32
- SonarQube Quality Gate passed (84.7% global coverage, 0 issues)
- ESLint and documentation tests passed