### PR TITLE
Release RadIA 2.17.10

### DIFF
--- a/RadIA.dproj
+++ b/RadIA.dproj
@@ -65,7 +65,7 @@
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.9.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.9.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.10.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.10.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     </PropertyGroup>
@@ -73,14 +73,14 @@
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.9.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.9.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.10.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.10.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64x)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.9.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.9.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.10.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.10.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <BCC_EnableBatchCompilation>true</BCC_EnableBatchCompilation>
     </PropertyGroup>

--- a/RadIA.rc
+++ b/RadIA.rc
@@ -1,6 +1,6 @@
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,17,9,0
-PRODUCTVERSION 2,17,9,0
+FILEVERSION 2,17,10,0
+PRODUCTVERSION 2,17,10,0
 FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -17,12 +17,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Rad IA Open Source Project\0"
             VALUE "FileDescription", "Rad IA - AI Assistant for Delphi IDE\0"
-            VALUE "FileVersion", "2.17.9.0\0"
+            VALUE "FileVersion", "2.17.10.0\0"
             VALUE "InternalName", "RadIA\0"
             VALUE "LegalCopyright", "Copyright (c) 2026\0"
             VALUE "OriginalFilename", "RadIA.bpl\0"
             VALUE "ProductName", "Rad IA\0"
-            VALUE "ProductVersion", "2.17.9.0\0"
+            VALUE "ProductVersion", "2.17.10.0\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/Source/Core/RadIA.Core.Version.pas
+++ b/Source/Core/RadIA.Core.Version.pas
@@ -3,7 +3,7 @@ unit RadIA.Core.Version;
 interface
 
 const
-  CRadIAVersion = '2.17.9';
+  CRadIAVersion = '2.17.10';
 
 function RadIAVersionedCaption(const ACaption: string): string;
 

--- a/Source/UI/RadIA.UI.ChatFrame.pas
+++ b/Source/UI/RadIA.UI.ChatFrame.pas
@@ -1190,6 +1190,7 @@ begin
     LTargetUrl := 'file:///' + TPath.Combine(FWebFilesDir, 'chat.html').Replace('\', '/') +
       '?theme=' + GetWebThemeName(GetCurrentIDEThemeName);
     TLogger.Log('UpdateWebViewNavigation: Navigating to local chat: ' + LTargetUrl, 'UI');
+    FPresenter.WebViewReady := False;
     FWebViewLifecycle.BeginNavigation;
     FEdgeBrowser.Navigate(LTargetUrl);
   end;

--- a/Source/UI/RadIA.UI.ChatPresenter.pas
+++ b/Source/UI/RadIA.UI.ChatPresenter.pas
@@ -75,6 +75,7 @@ type
     FLoadingConfig: Boolean;
     FWebViewReady: Boolean;
     FPendingWebMessages: TList<string>;
+    FPendingGlobalPrompt: string;
     FWebFilesDir: string;
     FLifecycleGuard: IInterface;
     FActiveModels: TArray<string>;
@@ -167,6 +168,7 @@ type
     function CanChangeSession: Boolean;
 
     procedure SendInitialConfigToWeb;
+    procedure SendDirectPromptText(const APromptText: string);
     procedure SendModelsUpdateToWeb(
       const AModels: TArray<string>;
       const AActiveModel: string;
@@ -581,6 +583,7 @@ begin
   FLoadingConfig := False;
   FWebViewReady := False;
   FPendingWebMessages := TList<string>.Create;
+  FPendingGlobalPrompt := '';
   FLifecycleGuard := TLifecycleGuard.Create;
   FActiveModels := [];
   FPendingPrompt := '';
@@ -1647,7 +1650,43 @@ end;
 
 procedure TRadIAChatPresenter.HandleGlobalPromptRequest(const APrompt: string; const AOpenChat: Boolean);
 begin
-  SendPromptText(APrompt);
+  if not FWebViewReady then
+  begin
+    FPendingGlobalPrompt := APrompt;
+    TLogger.Log(
+      'HandleGlobalPromptRequest: Prompt deferred until WebView is ready.',
+      'UI'
+    );
+    Exit;
+  end;
+  SendDirectPromptText(APrompt);
+end;
+
+procedure TRadIAChatPresenter.SendDirectPromptText(
+  const APromptText: string
+);
+var
+  LEffectiveSettings: TRadIAResolvedExecutionSettings;
+  LPreflightMessage: string;
+  LProcessed: string;
+begin
+  if TryHandleToolPrompt(APromptText) then
+    Exit;
+
+  EnsureJourneyProjectBoundary;
+  LProcessed := PreProcessPrompt(APromptText);
+  LEffectiveSettings := ResolveEffectiveExecutionSettings;
+  if not CheckChatPreflight(LEffectiveSettings, LPreflightMessage) then
+  begin
+    ShowChatPreflightFailure(APromptText, LPreflightMessage);
+    Exit;
+  end;
+  TLogger.Log(
+    'SendDirectPromptText: Executing explicit IDE action without agent planning.',
+    'UI'
+  );
+  PostToWebView('add_message', 'user', APromptText);
+  SendPromptToAI(LProcessed);
 end;
 
 procedure TRadIAChatPresenter.SendPrompt;
@@ -2238,6 +2277,7 @@ end;
 procedure TRadIAChatPresenter.OnWebViewReady;
 var
   LMsgStr: string;
+  LPendingGlobalPrompt: string;
 begin
   FWebViewReady := True;
   FView.ApplyCurrentTheme;
@@ -2248,6 +2288,11 @@ begin
     FView.PostMessageToWeb(LMsgStr);
   end;
   FPendingWebMessages.Clear;
+
+  LPendingGlobalPrompt := FPendingGlobalPrompt;
+  FPendingGlobalPrompt := '';
+  if not LPendingGlobalPrompt.IsEmpty then
+    SendDirectPromptText(LPendingGlobalPrompt);
 
   if FRequestInProgress then
   begin

--- a/Tests/Source/RadIA.Tests.ChatPresenter.pas
+++ b/Tests/Source/RadIA.Tests.ChatPresenter.pas
@@ -220,6 +220,8 @@ type
     [Test]
     procedure TestConversationalQuestionBypassesAgentPlan;
     [Test]
+    procedure TestExplicitEditorPromptWaitsForWebViewAndBypassesAgentPlan;
+    [Test]
     procedure TestDeclarativeExtensionCommandReloadsWithoutRestart;
     [Test]
     procedure TestDeclarativeExtensionAppearsInSlashCatalog;
@@ -1770,6 +1772,30 @@ begin
   DrainQueuedCalls;
 
   Assert.IsTrue(FMockView.RequestStateInProgress);
+  Assert.DoesNotContain(FMockView.PostedMessages.Text, '"action":"agent_state"');
+  Assert.DoesNotContain(FMockView.PostedMessages.Text, '"status":"awaitingApproval"');
+
+  FPresenter.CancelRequest;
+end;
+
+procedure TTestChatPresenter.
+  TestExplicitEditorPromptWaitsForWebViewAndBypassesAgentPlan;
+const
+  CPrompt = 'Implement the method from its reviewed comment.';
+begin
+  FPresenter.Initialize('C:\mock\web');
+  FPresenter.WebViewReady := False;
+
+  FPresenter.HandleGlobalPromptRequest(CPrompt, True);
+
+  Assert.IsFalse(FMockView.RequestStateInProgress);
+  Assert.DoesNotContain(FMockView.PostedMessages.Text, CPrompt);
+
+  FPresenter.OnWebViewReady;
+  DrainQueuedCalls;
+
+  Assert.IsTrue(FMockView.RequestStateInProgress);
+  Assert.Contains(FMockView.PostedMessages.Text, CPrompt);
   Assert.DoesNotContain(FMockView.PostedMessages.Text, '"action":"agent_state"');
   Assert.DoesNotContain(FMockView.PostedMessages.Text, '"status":"awaitingApproval"');
 

--- a/Tests/Web/RadIA.WebViewLifecycle.test.js
+++ b/Tests/Web/RadIA.WebViewLifecycle.test.js
@@ -15,6 +15,10 @@ test('chat uses bounded WebView recovery and shutdown-safe callbacks', () => {
   const ideSmoke = read('scripts/Test-RadIA.IDESmoke.ps1');
 
   assert.match(frame, /TRadIAWebViewLifecycle\.Create\(2\)/u);
+  assert.match(
+    frame,
+    /UpdateWebViewNavigation;[\s\S]*?FPresenter\.WebViewReady := False;[\s\S]*?FEdgeBrowser\.Navigate/u
+  );
   assert.match(frame, /OnProcessFailed := EdgeBrowserProcessFailed/u);
   assert.match(frame, /ScheduleWebViewRecovery/u);
   assert.doesNotMatch(frame, /FEdgeBrowser\.CloseBrowserProcess;/u);

--- a/docs/guides/mcp_integration_guide.en.md
+++ b/docs/guides/mcp_integration_guide.en.md
@@ -195,7 +195,7 @@ For reproducible automation, prefer `mcp.<pid>.json`.
 1. Open Delphi and a project.
 2. Confirm that `mcp.<pid>.json` exists.
 3. Start or reload the MCP server in the client.
-4. Verify that `initialize` reports RadIA `2.17.9`.
+4. Verify that `initialize` reports RadIA `2.17.10`.
 5. Call `tools/list`.
 6. Call `GetIDEState` and `GetActiveProject`.
 7. Test mutable consent only in a disposable project.

--- a/docs/guides/mcp_integration_guide.md
+++ b/docs/guides/mcp_integration_guide.md
@@ -215,7 +215,7 @@ Para automação reproduzível, prefira sempre `mcp.<pid>.json`.
 1. Abra o Delphi e um projeto.
 2. Confirme que `mcp.<pid>.json` foi criado.
 3. Inicie ou recarregue o servidor no cliente MCP.
-4. Verifique que `initialize` retorna RadIA `2.17.9`.
+4. Verifique que `initialize` retorna RadIA `2.17.10`.
 5. Execute `tools/list`.
 6. Chame `GetIDEState` e `GetActiveProject`.
 7. Para testar consentimento, use uma tool mutável somente em um projeto descartável.

--- a/docs/guides/user_guide_editor_generation.en.md
+++ b/docs/guides/user_guide_editor_generation.en.md
@@ -16,6 +16,12 @@ Rad IA connects natively to the Delphi code editor using the Open Tools API (OTA
    * **Optimize/Refactor (`/refactor`):** Rewrites code aiming for performance, readability, and compliance with Clean Code and SOLID principles.
    * **Find Bugs (`/bugs`):** Scans the code for memory leaks (missing try..finally blocks), unhandled exceptions, and logic flaws.
    * **Generate Unit Tests (`/test`):** Automatically generates structured test classes and methods using the DUnitX framework.
+   * **Create Implementation from Comment:** With the cursor inside an empty method that contains a
+     natural-language comment, directly generates the bounded implementation.
+
+Implementation creation is an explicit editor action. It waits for chat loading to finish, sends the
+request directly to the configured provider, and neither creates nor requests approval for an agent plan,
+even when Agent mode is enabled. Applying the generated code remains subject to user review.
 
 > The **Rad IA** submenu is inserted at the top of the editor context menu after the IDE builds its native items, preserving compatibility with Delphi 12/13 and menus added by other plugins.
 

--- a/docs/guides/user_guide_editor_generation.md
+++ b/docs/guides/user_guide_editor_generation.md
@@ -16,6 +16,12 @@ O Rad IA conecta-se nativamente ao editor de código do Delphi usando a Open Too
    * **Otimizar/Refatorar (`/refactor`):** Reescreve o código visando performance, legibilidade e aplicação de padrões Clean Code e SOLID.
    * **Localizar Bugs (`/bugs`):** Executa uma varredura em busca de memory leaks (ausência de try..finally), exceções não tratadas e falhas de lógica.
    * **Gerar Testes Unitários (`/test`):** Gera automaticamente classes e métodos de testes estruturados baseados no framework DUnitX.
+   * **Criar Implementação a partir de Comentário:** Com o cursor dentro de um método vazio que
+     contenha um comentário em linguagem natural, gera diretamente a implementação delimitada.
+
+A criação de implementação é uma ação explícita do editor. Ela aguarda o chat terminar de carregar,
+envia a solicitação diretamente ao provider configurado e não cria nem solicita aprovação de um plano,
+mesmo quando o modo Agent está habilitado. A aplicação do código continua sujeita à revisão do usuário.
 
 > O submenu **Rad IA** é inserido no topo do menu contextual do editor após a IDE montar os itens nativos, mantendo compatibilidade com Delphi 12/13 e com menus adicionados por outros plugins.
 

--- a/docs/guides/user_manual.en.md
+++ b/docs/guides/user_manual.en.md
@@ -1,4 +1,4 @@
-# Complete RadIA 2.17.9 user manual
+# Complete RadIA 2.17.10 user manual
 
 > Use `/help` to compare Chat, Agent, CLI, and MCP. When a plan awaits approval, select
 > **Approve plan** or type `/agent resume`.
@@ -36,7 +36,7 @@ layouts such as `Startup Layout` and `Debug Layout`. If the panel is closed befo
 remains closed in the next session; use `Tools > RadIA > Chat` to open it again.
 
 The chat panel caption and primary RadIA windows show the loaded version, for example
-`Rad IA Chat v2.17.9`, so support can confirm the installed build quickly.
+`Rad IA Chat v2.17.10`, so support can confirm the installed build quickly.
 
 Supported credentials are protected locally with Windows DPAPI. Ollama and LM Studio can run
 locally. See the [installation guide](../getting-started/install_config.en.md).
@@ -313,6 +313,11 @@ Consumer Web Login was removed. Use supported API keys, OAuth, or local provider
 
 RadIA can explain, review, refactor, optimize SQL, identify likely bugs and leaks, generate DUnitX
 tests, create XML documentation, analyze warnings, and generate method bodies from comments.
+
+**Create Implementation from Comment** waits until the chat panel is ready and runs directly through
+the configured provider. Because the menu click already expresses a bounded intent, this action neither
+creates nor requests approval for a plan, even when Agent mode is enabled. Generated code still requires
+review before it is applied.
 
 It also generates DTOs and models from JSON or DDL and can create complete Delphi project
 structures. Smart Diff lets users review generated changes before applying them.

--- a/docs/guides/user_manual.md
+++ b/docs/guides/user_manual.md
@@ -1,4 +1,4 @@
-# Manual completo do RadIA 2.17.9
+# Manual completo do RadIA 2.17.10
 
 > Para comparar Chat, Agent, CLI e MCP, use `/help`. Quando um plano aguardar aprovação, clique em
 > **Approve plan** ou digite `/agent resume`.
@@ -45,7 +45,7 @@ troca entre layouts nomeados, como `Startup Layout` e `Debug Layout`. Se o paine
 de sair, ele permanece fechado na sessão seguinte; use `Tools > RadIA > Chat` para abri-lo novamente.
 
 O caption do painel de chat e das janelas principais do RadIA mostra a versão carregada, por exemplo
-`Rad IA Chat v2.17.9`, para facilitar suporte e conferência de instalação.
+`Rad IA Chat v2.17.10`, para facilitar suporte e conferência de instalação.
 
 Se o painel ou package não aparecer:
 
@@ -385,6 +385,11 @@ Pelo menu contextual do editor, o RadIA pode:
 - revisar a unit;
 - criar o corpo de um método a partir de comentário;
 - analisar warnings de compilador, thread safety e recursos do Windows.
+
+**Create Implementation from Comment** aguarda o painel de chat ficar pronto e executa diretamente
+no provider configurado. Como o clique no menu já expressa uma intenção delimitada, essa ação não cria
+nem solicita aprovação de plano, mesmo quando o modo Agent está habilitado. O código gerado ainda deve
+ser revisado antes da aplicação.
 
 Sem seleção ativa, ações compatíveis usam a unit inteira como contexto.
 

--- a/docs/reference/cli_capability_matrix.en.md
+++ b/docs/reference/cli_capability_matrix.en.md
@@ -15,7 +15,7 @@
 
 ## Current matrix
 
-| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.9 use |
+| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.10 use |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Yes, JSONL | Structured event | `exec resume <id>` | Yes | Yes | Not declared | New execution per message |
 | Claude Code | Yes, stream JSON | Structured event | `--resume <id>` | Yes | Yes | Not declared | New execution per message |

--- a/docs/reference/cli_capability_matrix.md
+++ b/docs/reference/cli_capability_matrix.md
@@ -15,7 +15,7 @@
 
 ## Matriz atual
 
-| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.9 |
+| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.10 |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Sim, JSONL | Evento estruturado | `exec resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |
 | Claude Code | Sim, stream JSON | Evento estruturado | `--resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radia-plugin",
-  "version": "2.17.9",
+  "version": "2.17.10",
   "description": "Rad IA - AI Assistant for Delphi IDE",
   "main": "eslint.config.js",
   "scripts": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # SonarQube Project Configuration
 sonar.projectKey=radia
 sonar.projectName=radia
-sonar.projectVersion=2.17.9
+sonar.projectVersion=2.17.10
 
 # Path to the source directories
 sonar.sources=Source


### PR DESCRIPTION
## Release RadIA 2.17.10

Promotes the validated editor comment-completion fix from develop to main.

Validation includes Delphi 12/13 complete tests, all supported startup targets, nine release-critical journeys, generated projects, documentation, ESLint, and SonarQube Quality Gate.