### PR TITLE
release: RadIA 2.17.11

### DIFF
--- a/RadIA.dproj
+++ b/RadIA.dproj
@@ -65,7 +65,7 @@
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.10.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.10.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.11.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.11.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     </PropertyGroup>
@@ -73,14 +73,14 @@
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.10.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.10.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.11.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.11.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64x)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.10.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.10.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.11.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.11.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <BCC_EnableBatchCompilation>true</BCC_EnableBatchCompilation>
     </PropertyGroup>

--- a/RadIA.rc
+++ b/RadIA.rc
@@ -1,6 +1,6 @@
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,17,10,0
-PRODUCTVERSION 2,17,10,0
+FILEVERSION 2,17,11,0
+PRODUCTVERSION 2,17,11,0
 FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -17,12 +17,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Rad IA Open Source Project\0"
             VALUE "FileDescription", "Rad IA - AI Assistant for Delphi IDE\0"
-            VALUE "FileVersion", "2.17.10.0\0"
+            VALUE "FileVersion", "2.17.11.0\0"
             VALUE "InternalName", "RadIA\0"
             VALUE "LegalCopyright", "Copyright (c) 2026\0"
             VALUE "OriginalFilename", "RadIA.bpl\0"
             VALUE "ProductName", "Rad IA\0"
-            VALUE "ProductVersion", "2.17.10.0\0"
+            VALUE "ProductVersion", "2.17.11.0\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/Source/Core/RadIA.Core.Version.pas
+++ b/Source/Core/RadIA.Core.Version.pas
@@ -3,7 +3,7 @@ unit RadIA.Core.Version;
 interface
 
 const
-  CRadIAVersion = '2.17.10';
+  CRadIAVersion = '2.17.11';
 
 function RadIAVersionedCaption(const ACaption: string): string;
 

--- a/Source/Integration/RadIA.OTA.Helper.pas
+++ b/Source/Integration/RadIA.OTA.Helper.pas
@@ -166,22 +166,46 @@ class function TRadIAOTAHelper.ReplaceOriginalTextMatch(const AEditor: IRadIAEdi
   const ANewText, AOriginalText: string): Boolean;
 var
   LBufferText: string;
-  LMatchPos, LStartOffset, LLengthBytes: Integer;
+  LCandidate: string;
+
+  function TryReplaceCandidate(const ACandidate: string): Boolean;
+  var
+    LLengthBytes: Integer;
+    LMatchPos: Integer;
+    LStartOffset: Integer;
+  begin
+    Result := False;
+    LMatchPos := Pos(ACandidate, LBufferText);
+    if LMatchPos <= 0 then
+      Exit;
+
+    LStartOffset := System.SysUtils.TEncoding.UTF8.GetByteCount(
+      Copy(LBufferText, 1, LMatchPos - 1)
+    );
+    LLengthBytes := System.SysUtils.TEncoding.UTF8.GetByteCount(ACandidate);
+    AEditor.ReplaceText(LStartOffset, LLengthBytes, NormalizeLineBreaks(ANewText));
+    Result := True;
+  end;
 begin
   Result := False;
   if not Assigned(AEditor) then
     Exit;
 
   LBufferText := AEditor.GetText;
-  LMatchPos := Pos(AOriginalText, LBufferText);
-  if LMatchPos <= 0 then
-    Exit;
+  if TryReplaceCandidate(AOriginalText) then
+    Exit(True);
 
-  LStartOffset := System.SysUtils.TEncoding.UTF8.GetByteCount(Copy(LBufferText, 1, LMatchPos - 1));
-  LLengthBytes := System.SysUtils.TEncoding.UTF8.GetByteCount(AOriginalText);
+  LCandidate := NormalizeLineBreaks(AOriginalText);
+  if (LCandidate <> AOriginalText) and TryReplaceCandidate(LCandidate) then
+    Exit(True);
 
-  AEditor.ReplaceText(LStartOffset, LLengthBytes, NormalizeLineBreaks(ANewText));
-  Result := True;
+  LCandidate := LCandidate.Replace(#13#10, #10);
+  if (LCandidate <> AOriginalText) and TryReplaceCandidate(LCandidate) then
+    Exit(True);
+
+  LCandidate := LCandidate.Replace(#10, #13);
+  if (LCandidate <> AOriginalText) and TryReplaceCandidate(LCandidate) then
+    Exit(True);
 end;
 
 class function TRadIAOTAHelper.InsertFormattedText(const AEditor: IRadIAEditorAdapter;
@@ -217,17 +241,12 @@ begin
     if AReplaceWholeBuffer then
       Exit(ReplaceWholeBufferText(LEditor, ANewText));
 
+    if not AOriginalText.Trim.IsEmpty then
+      Exit(ReplaceOriginalTextMatch(LEditor, ANewText, AOriginalText));
+
     LSelectedText := LEditor.GetSelectedText;
     if not LSelectedText.IsEmpty then
-    begin
       LEditor.ReplaceSelection('');
-    end;
-
-    if LSelectedText.IsEmpty and not AOriginalText.Trim.IsEmpty then
-    begin
-      if ReplaceOriginalTextMatch(LEditor, ANewText, AOriginalText) then
-        Exit(True);
-    end;
 
     Result := InsertFormattedText(LEditor, ANewText);
   end;

--- a/Tests/Source/RadIA.Tests.OTAHelper.pas
+++ b/Tests/Source/RadIA.Tests.OTAHelper.pas
@@ -66,6 +66,10 @@ type
     [Test]
     procedure TestReplaceActiveEditorText;
     [Test]
+    procedure TestReplaceActiveEditorTextMatchesDifferentLineBreaks;
+    [Test]
+    procedure TestReplaceActiveEditorTextDoesNotInsertWhenTargetChanged;
+    [Test]
     procedure TestInsertTextAtCursor;
     [Test]
     procedure TestInsertTextAtLineColumn;
@@ -272,6 +276,40 @@ begin
   FMockEditor.CursorColumn := 10;
   Assert.IsTrue(TRadIAOTAHelper.ReplaceActiveEditorText('selected'));
   Assert.AreEqual('Original selected text'#13#10, FMockEditor.Text);
+end;
+
+procedure TTestOTAHelper.TestReplaceActiveEditorTextMatchesDifferentLineBreaks;
+const
+  COriginalMethod = 'procedure DoWork;'#13#10'begin'#13#10'  // implement'#13#10'end;';
+  CGeneratedMethod = 'procedure DoWork;'#13#10'begin'#13#10'  Run;'#13#10'end;';
+begin
+  FMockEditor.Text := 'implementation'#10#10 +
+    'procedure DoWork;'#10'begin'#10'  // implement'#10'end;'#10#10'end.';
+
+  Assert.IsTrue(
+    TRadIAOTAHelper.ReplaceActiveEditorText(CGeneratedMethod, False, COriginalMethod)
+  );
+  Assert.AreEqual(
+    'implementation'#10#10 + CGeneratedMethod + #10#10'end.',
+    FMockEditor.Text
+  );
+  Assert.Contains(FMockEditor.Text, '  Run;');
+  Assert.IsFalse(FMockEditor.Text.Contains('// implement'));
+end;
+
+procedure TTestOTAHelper.TestReplaceActiveEditorTextDoesNotInsertWhenTargetChanged;
+const
+  CChangedBuffer = 'procedure DoWork;'#13#10'begin'#13#10'  ExistingCode;'#13#10'end;';
+  COriginalMethod = 'procedure DoWork;'#13#10'begin'#13#10'  // implement'#13#10'end;';
+begin
+  FMockEditor.Text := CChangedBuffer;
+  FMockEditor.CursorLine := 3;
+  FMockEditor.CursorColumn := 3;
+
+  Assert.IsFalse(
+    TRadIAOTAHelper.ReplaceActiveEditorText('procedure DoWork; begin Run; end;', False, COriginalMethod)
+  );
+  Assert.AreEqual(CChangedBuffer, FMockEditor.Text);
 end;
 
 procedure TTestOTAHelper.TestInsertTextAtCursor;

--- a/docs/guides/mcp_integration_guide.en.md
+++ b/docs/guides/mcp_integration_guide.en.md
@@ -195,7 +195,7 @@ For reproducible automation, prefer `mcp.<pid>.json`.
 1. Open Delphi and a project.
 2. Confirm that `mcp.<pid>.json` exists.
 3. Start or reload the MCP server in the client.
-4. Verify that `initialize` reports RadIA `2.17.10`.
+4. Verify that `initialize` reports RadIA `2.17.11`.
 5. Call `tools/list`.
 6. Call `GetIDEState` and `GetActiveProject`.
 7. Test mutable consent only in a disposable project.

--- a/docs/guides/mcp_integration_guide.md
+++ b/docs/guides/mcp_integration_guide.md
@@ -215,7 +215,7 @@ Para automação reproduzível, prefira sempre `mcp.<pid>.json`.
 1. Abra o Delphi e um projeto.
 2. Confirme que `mcp.<pid>.json` foi criado.
 3. Inicie ou recarregue o servidor no cliente MCP.
-4. Verifique que `initialize` retorna RadIA `2.17.10`.
+4. Verifique que `initialize` retorna RadIA `2.17.11`.
 5. Execute `tools/list`.
 6. Chame `GetIDEState` e `GetActiveProject`.
 7. Para testar consentimento, use uma tool mutável somente em um projeto descartável.

--- a/docs/guides/user_guide_editor_generation.en.md
+++ b/docs/guides/user_guide_editor_generation.en.md
@@ -21,7 +21,9 @@ Rad IA connects natively to the Delphi code editor using the Open Tools API (OTA
 
 Implementation creation is an explicit editor action. It waits for chat loading to finish, sends the
 request directly to the configured provider, and neither creates nor requests approval for an agent plan,
-even when Agent mode is enabled. Applying the generated code remains subject to user review.
+even when Agent mode is enabled. The implementation replaces only the originally captured empty method. If
+that method changes while the response is generated, Rad IA cancels the application without inserting code at
+the current cursor position.
 
 > The **Rad IA** submenu is inserted at the top of the editor context menu after the IDE builds its native items, preserving compatibility with Delphi 12/13 and menus added by other plugins.
 

--- a/docs/guides/user_guide_editor_generation.md
+++ b/docs/guides/user_guide_editor_generation.md
@@ -21,7 +21,9 @@ O Rad IA conecta-se nativamente ao editor de código do Delphi usando a Open Too
 
 A criação de implementação é uma ação explícita do editor. Ela aguarda o chat terminar de carregar,
 envia a solicitação diretamente ao provider configurado e não cria nem solicita aprovação de um plano,
-mesmo quando o modo Agent está habilitado. A aplicação do código continua sujeita à revisão do usuário.
+mesmo quando o modo Agent está habilitado. A implementação substitui somente o método vazio originalmente
+capturado. Se esse método mudar enquanto a resposta é gerada, o Rad IA cancela a aplicação sem inserir código
+na posição atual do cursor.
 
 > O submenu **Rad IA** é inserido no topo do menu contextual do editor após a IDE montar os itens nativos, mantendo compatibilidade com Delphi 12/13 e com menus adicionados por outros plugins.
 

--- a/docs/guides/user_manual.en.md
+++ b/docs/guides/user_manual.en.md
@@ -1,4 +1,4 @@
-# Complete RadIA 2.17.10 user manual
+# Complete RadIA 2.17.11 user manual
 
 > Use `/help` to compare Chat, Agent, CLI, and MCP. When a plan awaits approval, select
 > **Approve plan** or type `/agent resume`.
@@ -36,7 +36,7 @@ layouts such as `Startup Layout` and `Debug Layout`. If the panel is closed befo
 remains closed in the next session; use `Tools > RadIA > Chat` to open it again.
 
 The chat panel caption and primary RadIA windows show the loaded version, for example
-`Rad IA Chat v2.17.10`, so support can confirm the installed build quickly.
+`Rad IA Chat v2.17.11`, so support can confirm the installed build quickly.
 
 Supported credentials are protected locally with Windows DPAPI. Ollama and LM Studio can run
 locally. See the [installation guide](../getting-started/install_config.en.md).
@@ -316,8 +316,9 @@ tests, create XML documentation, analyze warnings, and generate method bodies fr
 
 **Create Implementation from Comment** waits until the chat panel is ready and runs directly through
 the configured provider. Because the menu click already expresses a bounded intent, this action neither
-creates nor requests approval for a plan, even when Agent mode is enabled. Generated code still requires
-review before it is applied.
+creates nor requests approval for a plan, even when Agent mode is enabled. The code replaces only the captured
+empty method. If that method changes during generation, the application is cancelled without inserting code
+at the cursor.
 
 It also generates DTOs and models from JSON or DDL and can create complete Delphi project
 structures. Smart Diff lets users review generated changes before applying them.

--- a/docs/guides/user_manual.md
+++ b/docs/guides/user_manual.md
@@ -1,4 +1,4 @@
-# Manual completo do RadIA 2.17.10
+# Manual completo do RadIA 2.17.11
 
 > Para comparar Chat, Agent, CLI e MCP, use `/help`. Quando um plano aguardar aprovação, clique em
 > **Approve plan** ou digite `/agent resume`.
@@ -45,7 +45,7 @@ troca entre layouts nomeados, como `Startup Layout` e `Debug Layout`. Se o paine
 de sair, ele permanece fechado na sessão seguinte; use `Tools > RadIA > Chat` para abri-lo novamente.
 
 O caption do painel de chat e das janelas principais do RadIA mostra a versão carregada, por exemplo
-`Rad IA Chat v2.17.10`, para facilitar suporte e conferência de instalação.
+`Rad IA Chat v2.17.11`, para facilitar suporte e conferência de instalação.
 
 Se o painel ou package não aparecer:
 
@@ -388,8 +388,9 @@ Pelo menu contextual do editor, o RadIA pode:
 
 **Create Implementation from Comment** aguarda o painel de chat ficar pronto e executa diretamente
 no provider configurado. Como o clique no menu já expressa uma intenção delimitada, essa ação não cria
-nem solicita aprovação de plano, mesmo quando o modo Agent está habilitado. O código gerado ainda deve
-ser revisado antes da aplicação.
+nem solicita aprovação de plano, mesmo quando o modo Agent está habilitado. O código substitui somente o
+método vazio capturado. Se esse método mudar durante a geração, a aplicação é cancelada sem inserir código
+no cursor.
 
 Sem seleção ativa, ações compatíveis usam a unit inteira como contexto.
 

--- a/docs/reference/cli_capability_matrix.en.md
+++ b/docs/reference/cli_capability_matrix.en.md
@@ -15,7 +15,7 @@
 
 ## Current matrix
 
-| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.10 use |
+| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.11 use |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Yes, JSONL | Structured event | `exec resume <id>` | Yes | Yes | Not declared | New execution per message |
 | Claude Code | Yes, stream JSON | Structured event | `--resume <id>` | Yes | Yes | Not declared | New execution per message |

--- a/docs/reference/cli_capability_matrix.md
+++ b/docs/reference/cli_capability_matrix.md
@@ -15,7 +15,7 @@
 
 ## Matriz atual
 
-| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.10 |
+| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.11 |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Sim, JSONL | Evento estruturado | `exec resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |
 | Claude Code | Sim, stream JSON | Evento estruturado | `--resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radia-plugin",
-  "version": "2.17.10",
+  "version": "2.17.11",
   "description": "Rad IA - AI Assistant for Delphi IDE",
   "main": "eslint.config.js",
   "scripts": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # SonarQube Project Configuration
 sonar.projectKey=radia
 sonar.projectName=radia
-sonar.projectVersion=2.17.10
+sonar.projectVersion=2.17.11
 
 # Path to the source directories
 sonar.sources=Source


### PR DESCRIPTION
Promove a correção segura de Create Implementation from Comment para a versão 2.17.11. Gates completos do Delphi 12/13, matriz de uso e SonarQube aprovados.