### PR TITLE
Fix validated project creation completion

### DIFF
--- a/RadIA.dproj
+++ b/RadIA.dproj
@@ -65,7 +65,7 @@
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.11.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.11.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.12.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.12.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     </PropertyGroup>
@@ -73,14 +73,14 @@
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.11.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.11.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.12.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.12.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64x)'!=''">
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.11.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.11.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=2.17.12.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.17.12.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <BCC_EnableBatchCompilation>true</BCC_EnableBatchCompilation>
     </PropertyGroup>

--- a/RadIA.rc
+++ b/RadIA.rc
@@ -1,6 +1,6 @@
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,17,11,0
-PRODUCTVERSION 2,17,11,0
+FILEVERSION 2,17,12,0
+PRODUCTVERSION 2,17,12,0
 FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -17,12 +17,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Rad IA Open Source Project\0"
             VALUE "FileDescription", "Rad IA - AI Assistant for Delphi IDE\0"
-            VALUE "FileVersion", "2.17.11.0\0"
+            VALUE "FileVersion", "2.17.12.0\0"
             VALUE "InternalName", "RadIA\0"
             VALUE "LegalCopyright", "Copyright (c) 2026\0"
             VALUE "OriginalFilename", "RadIA.bpl\0"
             VALUE "ProductName", "Rad IA\0"
-            VALUE "ProductVersion", "2.17.11.0\0"
+            VALUE "ProductVersion", "2.17.12.0\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/Source/Core/RadIA.Core.AgentProvider.pas
+++ b/Source/Core/RadIA.Core.AgentProvider.pas
@@ -242,7 +242,12 @@ begin
     'project, or Designer mutation, inspect structured diagnostics and run ' +
     'BuildProject. Never complete while CURRENT_STATE.validation.buildPassed ' +
     'is false. For project creation, treat a successful build as the default ' +
-    'final gate. Call StartDebugging or runtime scenario tools only when the ' +
+    'final gate. After PreviewProjectTemplate, CreateProjectFromTemplate, ' +
+    'OpenCreatedProject, and a successful BuildProject, complete immediately. ' +
+    'Do not list, navigate to, read, or audit generated template files merely ' +
+    'to reconfirm content already guaranteed by the reviewed template. Only ' +
+    'continue when the objective explicitly requires tests, runtime validation, ' +
+    'or another unmet result. Call StartDebugging or runtime scenario tools only when the ' +
     'objective contains runtimeValidation="required". Keep a runtime failure ' +
     'separate from successful build evidence. When DUnitX tests are available, ' +
     'run RunDUnitXTests after a ' +

--- a/Source/Core/RadIA.Core.AgentRuntime.pas
+++ b/Source/Core/RadIA.Core.AgentRuntime.pas
@@ -490,6 +490,9 @@ type
     function ProjectCreationAllowsCompletion(
       out AMessage: string
     ): Boolean;
+    function TryCompleteValidatedProjectCreation(
+      const AToolName: string
+    ): Boolean;
   public
     constructor Create(
       const AToolExecutor: IRadIAToolExecutor;
@@ -2497,7 +2500,29 @@ begin
   end;
   if not CheckExecutionContract then
     Exit(True);
+  if TryCompleteValidatedProjectCreation(ADecision.ToolName) then
+    Exit(True);
   NotifyAndCheckpoint;
+  Result := True;
+end;
+
+function TRadIAAgentRuntime.TryCompleteValidatedProjectCreation(
+  const AToolName: string
+): Boolean;
+var
+  LValidationMessage: string;
+begin
+  Result := False;
+  if not SameText(AToolName, 'BuildProject') or
+    not IsProjectCreationObjective then
+    Exit;
+  if not ValidationAllowsCompletion(LValidationMessage) then
+    Exit;
+
+  ChangeStatus(
+    asCompleted,
+    'The requested project was created, opened in Delphi, and built successfully.'
+  );
   Result := True;
 end;
 

--- a/Source/Core/RadIA.Core.Version.pas
+++ b/Source/Core/RadIA.Core.Version.pas
@@ -3,7 +3,7 @@ unit RadIA.Core.Version;
 interface
 
 const
-  CRadIAVersion = '2.17.11';
+  CRadIAVersion = '2.17.12';
 
 function RadIAVersionedCaption(const ACaption: string): string;
 

--- a/Source/UI/Web/chat.js
+++ b/Source/UI/Web/chat.js
@@ -1030,7 +1030,9 @@ function renderProjectOperationSummary(card, state) {
     item.setAttribute('aria-current', stageState === 'current' ? 'step' : 'false');
     marker.className = 'agent-operation-marker';
     marker.setAttribute('aria-hidden', 'true');
-    label.textContent = stage.label;
+    label.textContent = stage.id === 'complete' && stageState === 'current'
+      ? 'Finalizing project validation'
+      : stage.label;
     item.append(marker, label);
     stagesElement.appendChild(item);
   });

--- a/Tests/Source/RadIA.Tests.AgentRuntime.pas
+++ b/Tests/Source/RadIA.Tests.AgentRuntime.pas
@@ -1327,6 +1327,14 @@ begin
     LServiceObject.Prompt,
     'When GetToolResultRange returns hasMore=false'
   );
+  Assert.Contains(
+    LServiceObject.Prompt,
+    'a successful BuildProject, complete immediately'
+  );
+  Assert.Contains(
+    LServiceObject.Prompt,
+    'Do not list, navigate to, read, or audit generated template files'
+  );
 end;
 
 procedure TTestRadIAAgentRuntime.TestProviderLimitsProjectCreationToolCatalog;
@@ -1754,7 +1762,10 @@ begin
     Assert.AreEqual(asAwaitingApproval, LResult.Status);
     LResult := LRuntime.Resume('project-creation-gate-session');
     Assert.AreEqual(asCompleted, LResult.Status);
-    Assert.AreEqual('Project created and built.', LResult.Message);
+    Assert.AreEqual(
+      'The requested project was created, opened in Delphi, and built successfully.',
+      LResult.Message
+    );
     Assert.AreEqual(4, LExecutorObject.CallCount);
   finally
     LRuntime.Free;

--- a/Tests/Web/RadIA.OperationalExperience.test.js
+++ b/Tests/Web/RadIA.OperationalExperience.test.js
@@ -20,6 +20,7 @@ test('project creation exposes a stable user-facing operation timeline', () => {
     'Creating project files',
     'Opening project in Delphi',
     'Building the project',
+    'Finalizing project validation',
     'Project ready'
   ];
   labels.forEach(label => assert.match(chatScript, new RegExp(label, 'u')));

--- a/docs/guides/mcp_integration_guide.en.md
+++ b/docs/guides/mcp_integration_guide.en.md
@@ -195,7 +195,7 @@ For reproducible automation, prefer `mcp.<pid>.json`.
 1. Open Delphi and a project.
 2. Confirm that `mcp.<pid>.json` exists.
 3. Start or reload the MCP server in the client.
-4. Verify that `initialize` reports RadIA `2.17.11`.
+4. Verify that `initialize` reports RadIA `2.17.12`.
 5. Call `tools/list`.
 6. Call `GetIDEState` and `GetActiveProject`.
 7. Test mutable consent only in a disposable project.

--- a/docs/guides/mcp_integration_guide.md
+++ b/docs/guides/mcp_integration_guide.md
@@ -215,7 +215,7 @@ Para automação reproduzível, prefira sempre `mcp.<pid>.json`.
 1. Abra o Delphi e um projeto.
 2. Confirme que `mcp.<pid>.json` foi criado.
 3. Inicie ou recarregue o servidor no cliente MCP.
-4. Verifique que `initialize` retorna RadIA `2.17.11`.
+4. Verifique que `initialize` retorna RadIA `2.17.12`.
 5. Execute `tools/list`.
 6. Chame `GetIDEState` e `GetActiveProject`.
 7. Para testar consentimento, use uma tool mutável somente em um projeto descartável.

--- a/docs/guides/user_manual.en.md
+++ b/docs/guides/user_manual.en.md
@@ -1,4 +1,4 @@
-# Complete RadIA 2.17.11 user manual
+# Complete RadIA 2.17.12 user manual
 
 > Use `/help` to compare Chat, Agent, CLI, and MCP. When a plan awaits approval, select
 > **Approve plan** or type `/agent resume`.
@@ -36,7 +36,7 @@ layouts such as `Startup Layout` and `Debug Layout`. If the panel is closed befo
 remains closed in the next session; use `Tools > RadIA > Chat` to open it again.
 
 The chat panel caption and primary RadIA windows show the loaded version, for example
-`Rad IA Chat v2.17.11`, so support can confirm the installed build quickly.
+`Rad IA Chat v2.17.12`, so support can confirm the installed build quickly.
 
 Supported credentials are protected locally with Windows DPAPI. Ollama and LM Studio can run
 locally. See the [installation guide](../getting-started/install_config.en.md).
@@ -200,7 +200,10 @@ To enable monetary estimates and enforcement, configure the
 
 During project creation, the execution center first presents a stable operational view: preparation,
 structure review, file creation, opening in Delphi, build, and completion. The current stage remains
-highlighted while work continues. The card explicitly states that DUnitX and other additions are not
+highlighted while work continues; before final confirmation, the card shows **Finalizing project
+validation**, not **Project ready**. For template-based creation, a successful build completes the run
+immediately when tests or runtime validation were not requested. The agent does not reread or audit
+generated files merely to reconfirm the template. The card explicitly states that DUnitX and other additions are not
 created automatically and shows the expected result before execution finishes. Metrics, risks,
 evidence, and arguments remain available under **Technical details** without dominating the primary
 reading path. After a successful build, actions such as **Add DUnitX tests** only prepare a new

--- a/docs/guides/user_manual.md
+++ b/docs/guides/user_manual.md
@@ -1,4 +1,4 @@
-# Manual completo do RadIA 2.17.11
+# Manual completo do RadIA 2.17.12
 
 > Para comparar Chat, Agent, CLI e MCP, use `/help`. Quando um plano aguardar aprovação, clique em
 > **Approve plan** ou digite `/agent resume`.
@@ -45,7 +45,7 @@ troca entre layouts nomeados, como `Startup Layout` e `Debug Layout`. Se o paine
 de sair, ele permanece fechado na sessão seguinte; use `Tools > RadIA > Chat` para abri-lo novamente.
 
 O caption do painel de chat e das janelas principais do RadIA mostra a versão carregada, por exemplo
-`Rad IA Chat v2.17.11`, para facilitar suporte e conferência de instalação.
+`Rad IA Chat v2.17.12`, para facilitar suporte e conferência de instalação.
 
 Se o painel ou package não aparecer:
 
@@ -240,7 +240,11 @@ Para habilitar a estimativa e o limite monetário, configure o
 
 Na criação de projetos, a central apresenta primeiro uma visão operacional estável: preparação,
 revisão da estrutura, criação dos arquivos, abertura no Delphi, build e conclusão. A etapa atual
-permanece destacada enquanto o trabalho acontece. O cartão informa explicitamente que DUnitX e
+permanece destacada enquanto o trabalho acontece; antes da confirmação final, o cartão mostra
+**Finalizing project validation**, e não **Project ready**. Para criações por template, um build
+aprovado encerra imediatamente a execução quando testes ou validação em runtime não foram solicitados.
+O agente não relê nem audita arquivos gerados apenas para reconfirmar o template. O cartão informa
+explicitamente que DUnitX e
 outros adicionais não serão criados automaticamente e mostra o resultado esperado antes da
 execução terminar. Métricas, riscos, evidências e argumentos continuam disponíveis em
 **Technical details**, sem ocupar a leitura principal. Depois de um build bem-sucedido, ações como

--- a/docs/reference/cli_capability_matrix.en.md
+++ b/docs/reference/cli_capability_matrix.en.md
@@ -15,7 +15,7 @@
 
 ## Current matrix
 
-| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.11 use |
+| Executor | Structured output | Session ID | Stable resume | Model | MCP | Dedicated FIM | RadIA 2.17.12 use |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Yes, JSONL | Structured event | `exec resume <id>` | Yes | Yes | Not declared | New execution per message |
 | Claude Code | Yes, stream JSON | Structured event | `--resume <id>` | Yes | Yes | Not declared | New execution per message |

--- a/docs/reference/cli_capability_matrix.md
+++ b/docs/reference/cli_capability_matrix.md
@@ -15,7 +15,7 @@
 
 ## Matriz atual
 
-| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.11 |
+| Executor | Saída estruturada | ID de sessão | Retomada estável | Modelo | MCP | FIM dedicado | Uso no RadIA 2.17.12 |
 |---|---:|---:|---:|---:|---:|---:|---|
 | Codex CLI | Sim, JSONL | Evento estruturado | `exec resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |
 | Claude Code | Sim, stream JSON | Evento estruturado | `--resume <id>` | Sim | Sim | Não declarado | Nova execução por mensagem |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radia-plugin",
-  "version": "2.17.11",
+  "version": "2.17.12",
   "description": "Rad IA - AI Assistant for Delphi IDE",
   "main": "eslint.config.js",
   "scripts": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # SonarQube Project Configuration
 sonar.projectKey=radia
 sonar.projectName=radia
-sonar.projectVersion=2.17.11
+sonar.projectVersion=2.17.12
 
 # Path to the source directories
 sonar.sources=Source


### PR DESCRIPTION
## Summary
- finish project creation immediately after a successful validated build
- avoid redundant generated-file inspection and provider turns
- show a truthful final validation stage in the agent UI
- update tests, documentation, and version to 2.17.12

## Validation
- Delphi 12 and 13: 1420 DUnitX + 8 external tests passed
- release usage and startup matrices passed
- web lint, operational tests, and documentation tests passed
- SonarQube Quality Gate passed with zero new violations